### PR TITLE
Update WalletViewController cells and more...

### DIFF
--- a/FullyNoded2/FullyNoded2.xcodeproj/project.pbxproj
+++ b/FullyNoded2/FullyNoded2.xcodeproj/project.pbxproj
@@ -1283,7 +1283,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = FullyNoded2/FullyNoded2.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 0.0.47;
+				CURRENT_PROJECT_VERSION = 0.0.48;
 				DEVELOPMENT_TEAM = YZHG975W3A;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1296,7 +1296,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.47;
+				MARKETING_VERSION = 0.0.48;
 				PRODUCT_BUNDLE_IDENTIFIER = com.blockchaincommons.standupios;
 				PRODUCT_NAME = "FullyNoded 2";
 				SUPPORTS_MACCATALYST = NO;
@@ -1312,7 +1312,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = FullyNoded2/FullyNoded2.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 0.0.47;
+				CURRENT_PROJECT_VERSION = 0.0.48;
 				DEVELOPMENT_TEAM = YZHG975W3A;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1325,7 +1325,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.47;
+				MARKETING_VERSION = 0.0.48;
 				PRODUCT_BUNDLE_IDENTIFIER = com.blockchaincommons.standupios;
 				PRODUCT_NAME = "FullyNoded 2";
 				SUPPORTS_MACCATALYST = NO;

--- a/FullyNoded2/FullyNoded2.xcodeproj/project.pbxproj
+++ b/FullyNoded2/FullyNoded2.xcodeproj/project.pbxproj
@@ -1283,7 +1283,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = FullyNoded2/FullyNoded2.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 0.0.46;
+				CURRENT_PROJECT_VERSION = 0.0.47;
 				DEVELOPMENT_TEAM = YZHG975W3A;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1296,7 +1296,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.46;
+				MARKETING_VERSION = 0.0.47;
 				PRODUCT_BUNDLE_IDENTIFIER = com.blockchaincommons.standupios;
 				PRODUCT_NAME = "FullyNoded 2";
 				SUPPORTS_MACCATALYST = NO;
@@ -1312,7 +1312,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = FullyNoded2/FullyNoded2.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 0.0.46;
+				CURRENT_PROJECT_VERSION = 0.0.47;
 				DEVELOPMENT_TEAM = YZHG975W3A;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1325,7 +1325,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.46;
+				MARKETING_VERSION = 0.0.47;
 				PRODUCT_BUNDLE_IDENTIFIER = com.blockchaincommons.standupios;
 				PRODUCT_NAME = "FullyNoded 2";
 				SUPPORTS_MACCATALYST = NO;

--- a/FullyNoded2/FullyNoded2/Helpers/DescriptorParser.swift
+++ b/FullyNoded2/FullyNoded2/Helpers/DescriptorParser.swift
@@ -33,6 +33,55 @@ class DescriptorParser {
         
         var dict = [String:Any]()
         
+        if descriptor.contains("[") && descriptor.contains("]") {
+            
+            let arr1 = descriptor.split(separator: "[")
+            let arr2 = arr1[1].split(separator: "]")
+            let derivation = arr2[0]
+            let arr3 = derivation.split(separator: "/")
+            var path = "m"
+            
+            for (i, item) in arr3.enumerated() {
+                
+                switch i {
+                    
+//                case 0:
+//                    let fingerprint = item
+                    
+                case 1:
+                    let type = item
+                    path += "/" + type
+                    
+                default:
+                    
+                    path += "/" + item
+                    
+                }
+                
+            }
+            
+            switch path {
+                
+            case "m/44'/0'/0'":
+                dict["isBIP44"] = true
+                dict["isP2PKH"] = true
+                
+            case "m/84'/0'/0'":
+                dict["isBIP84"] = true
+                dict["isP2WPKH"] = true
+                
+            case "m/49'/0'/0'":
+                dict["isBIP49"] = true
+                dict["isP2SHP2WPKH"] = true
+                
+            default:
+                
+                break
+                
+            }
+            
+        }
+        
         if descriptor.contains("multi") {
             
             dict["isMulti"] = true
@@ -93,22 +142,6 @@ class DescriptorParser {
                     
                 }
                 
-                if descriptor.contains("xpub") {
-                    
-                    dict["chain"] = "Mainnet"
-                    
-                } else if descriptor.contains("tpub") {
-                    
-                    dict["chain"] = "Testnet"
-                    
-                }
-                
-                if descriptor.contains("xprv") || descriptor.contains("tprv") {
-                    
-                    dict["isHot"] = true
-                    
-                }
-                
             }
                         
         } else {
@@ -130,12 +163,14 @@ class DescriptorParser {
                         case "wpkh":
                             
                             dict["format"] = "P2WPKH"
+                            dict["isP2WPKH"] = true
                             
                         case "sh":
                             
                             if arr[1] == "wpkh" {
                                 
                                 dict["format"] = "P2SH-P2WPKH"
+                                dict["isP2SHP2WPKH"] = true
                                 
                             } else {
                                 
@@ -150,6 +185,7 @@ class DescriptorParser {
                         case "pkh":
                             
                             dict["format"] = "P2PKH"
+                            dict["isP2PKH"] = true
                             
                         default:
                             
@@ -162,6 +198,22 @@ class DescriptorParser {
                 }
                 
             }
+            
+        }
+        
+        if descriptor.contains("xpub") || descriptor.contains("xprv") {
+            
+            dict["chain"] = "Mainnet"
+            
+        } else if descriptor.contains("tpub") || descriptor.contains("tprv") {
+            
+            dict["chain"] = "Testnet"
+            
+        }
+        
+        if descriptor.contains("xprv") || descriptor.contains("tprv") {
+            
+            dict["isHot"] = true
             
         }
         

--- a/FullyNoded2/FullyNoded2/Helpers/FiatConverter.swift
+++ b/FullyNoded2/FullyNoded2/Helpers/FiatConverter.swift
@@ -21,8 +21,10 @@ class FiatConverter {
         torClient = TorClient.sharedInstance
         
         var url:NSURL!
-        //http://blkchairbknpn73cfjhevhla7rkp4ed5gg2knctvv7it4lioy22defid.onion
-        url = NSURL(string: "https://api.coindesk.com/v1/bpi/currentprice.json")
+        //http://blkchairbknpn73cfjhevhla7rkp4ed5gg2knctvv7it4lioy22defid.onion/www/bitcoin/stats
+        //http://blockchairt5d4pj.onion/www/bitcoin/stats
+        //url = NSURL(string: "https://api.coindesk.com/v1/bpi/currentprice.json")
+        url = NSURL(string: "http://blkchairbknpn73cfjhevhla7rkp4ed5gg2knctvv7it4lioy22defid.onion/www/bitcoin/stats")
         
         let task = torClient.session.dataTask(with: url! as URL) { (data, response, error) -> Void in
             
@@ -43,18 +45,14 @@ class FiatConverter {
                             
                             print("json = \(json)")
                             
-                            if let exchangeCheck = json["bpi"] as? NSDictionary {
+                            if let data = json["data"] as? NSDictionary {
                                 
-                                if let usdCheck = exchangeCheck["USD"] as? NSDictionary {
-                                    
-                                    if let rateCheck = usdCheck["rate_float"] as? Double {
+                                if let rateCheck = data["market_price_usd"] as? Double {
                                         
                                         self.errorBool = false
                                         self.fxRate = rateCheck
                                         completion()
-                                        
-                                    }
-                                    
+                                                                            
                                 }
                                 
                             }

--- a/FullyNoded2/FullyNoded2/Helpers/FirstTime.swift
+++ b/FullyNoded2/FullyNoded2/Helpers/FirstTime.swift
@@ -73,7 +73,8 @@ class FirstTime {
                 
             } else {
                 
-                print("keychain set privkey")
+                print("keychain did not set privkey")
+                completion(false)
                 
             }
             

--- a/FullyNoded2/FullyNoded2/Helpers/Reducer.swift
+++ b/FullyNoded2/FullyNoded2/Helpers/Reducer.swift
@@ -116,6 +116,18 @@ class Reducer {
                             
                         }
                         
+                    } else if torRPC.errorDescription.contains("Could not connect to server") {
+                        
+                        print("restarting tor")
+                        
+                        TorClient.sharedInstance.start {
+                            
+                            self.torRPC.executeRPCCommand(walletName: walletName, method: command,
+                                                          param: param,
+                                                          completion: getResult)
+                            
+                        }
+                        
                     } else {
                         
                         errorBool = true

--- a/FullyNoded2/FullyNoded2/Helpers/Tor/TorClient.swift
+++ b/FullyNoded2/FullyNoded2/Helpers/Tor/TorClient.swift
@@ -155,8 +155,8 @@ class TorClient {
         
         clearAuthKeys {}
         isOperational = false
-        controller.disconnect()
-        controller = nil
+        //controller.disconnect()
+        //controller = nil
 
         // More cleanup
         thread.cancel()

--- a/FullyNoded2/FullyNoded2/Main.storyboard
+++ b/FullyNoded2/FullyNoded2/Main.storyboard
@@ -268,23 +268,40 @@
         <!--Authenticate-->
         <scene sceneID="uhr-cc-fch">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" id="FI5-Kv-Y72" customClass="AuthenticateViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="FI5-Kv-Y72" customClass="AuthenticateViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="xx3-cn-bLQ">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="In order to authenticate your connection you need to add this public key to the macOS StandUp.app in &quot;Settings&quot;. " lineBreakMode="tailTruncation" numberOfLines="6" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xaH-Sk-RIJ">
-                                <rect key="frame" x="16" y="14" width="343" height="54"/>
+                                <rect key="frame" x="16" y="44" width="343" height="70"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="70" id="T1E-VO-2Hs"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <color key="textColor" cocoaTouchSystemColor="lightTextColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3d6-K5-tGz">
+                                <rect key="frame" x="326" y="10" width="20" height="22"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="20" id="9iJ-hs-a9m"/>
+                                    <constraint firstAttribute="height" constant="22" id="vBL-qM-lmD"/>
+                                </constraints>
+                                <color key="tintColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <state key="normal" image="xmark.circle.fill" catalog="system"/>
+                                <connections>
+                                    <action selector="close:" destination="FI5-Kv-Y72" eventType="touchUpInside" id="0JZ-9g-6UY"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="0.074236519629999997" green="0.082159139219999996" blue="0.094636552040000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="xaH-Sk-RIJ" firstAttribute="top" secondItem="4te-9n-iGJ" secondAttribute="top" constant="14" id="EnV-fa-BfX"/>
-                            <constraint firstItem="4te-9n-iGJ" firstAttribute="trailing" secondItem="xaH-Sk-RIJ" secondAttribute="trailing" constant="16" id="UT7-3c-EaP"/>
-                            <constraint firstItem="xaH-Sk-RIJ" firstAttribute="leading" secondItem="4te-9n-iGJ" secondAttribute="leading" constant="16" id="weu-WF-JWN"/>
+                            <constraint firstItem="3d6-K5-tGz" firstAttribute="top" secondItem="4te-9n-iGJ" secondAttribute="top" constant="10" id="0py-wc-0lo"/>
+                            <constraint firstItem="xaH-Sk-RIJ" firstAttribute="top" secondItem="3d6-K5-tGz" secondAttribute="bottom" constant="12" id="5Ph-an-kq7"/>
+                            <constraint firstItem="4te-9n-iGJ" firstAttribute="trailing" secondItem="xaH-Sk-RIJ" secondAttribute="trailing" constant="16" id="ZYz-ZD-P3F"/>
+                            <constraint firstItem="4te-9n-iGJ" firstAttribute="trailing" secondItem="3d6-K5-tGz" secondAttribute="trailing" constant="29" id="a5b-Hc-ULC"/>
+                            <constraint firstItem="xaH-Sk-RIJ" firstAttribute="leading" secondItem="4te-9n-iGJ" secondAttribute="leading" constant="16" id="qbF-zw-4Ta"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="4te-9n-iGJ"/>
                     </view>
@@ -295,7 +312,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="0dh-vH-Z0p" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-7458" y="2001"/>
+            <point key="canvasLocation" x="-7458.3999999999996" y="2000.1499250374814"/>
         </scene>
         <!--Security View Controller-->
         <scene sceneID="iZu-HS-qu2">
@@ -3175,34 +3192,35 @@ You may export the public key descriptor at anytime but the 12 word recovery phr
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="insetGrouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="JXW-QX-3AG">
-                                <rect key="frame" x="0.0" y="115" width="375" height="503"/>
+                                <rect key="frame" x="0.0" y="107" width="375" height="512"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="coldWalletCell" rowHeight="310" id="Cjy-2R-y2B">
-                                        <rect key="frame" x="15" y="55.5" width="345" height="310"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="coldWalletCell" rowHeight="294" id="Cjy-2R-y2B">
+                                        <rect key="frame" x="0.0" y="55.5" width="345" height="294"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Cjy-2R-y2B" id="85P-mu-gZ2">
-                                            <rect key="frame" x="0.0" y="0.0" width="345" height="310"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="345" height="294"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <view clipsSubviews="YES" tag="26" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7cK-yo-h4f">
-                                                    <rect key="frame" x="15" y="189" width="314" height="55"/>
+                                                    <rect key="frame" x="15" y="164" width="314" height="74"/>
                                                     <subviews>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="desktopcomputer" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="lvy-X2-fvE">
-                                                            <rect key="frame" x="3" y="4.5" width="29" height="18"/>
+                                                            <rect key="frame" x="3" y="4.5" width="33" height="18"/>
+                                                            <color key="tintColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="19" id="8Xc-66-IPD"/>
-                                                                <constraint firstAttribute="width" constant="29" id="GXa-3W-6Dc"/>
+                                                                <constraint firstAttribute="width" constant="33" id="GXa-3W-6Dc"/>
                                                             </constraints>
                                                         </imageView>
                                                         <label opaque="NO" userInteractionEnabled="NO" tag="20" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="uhRD45u_StandUp.dat" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ATh-mZ-6tE">
-                                                            <rect key="frame" x="120" y="37" width="110" height="12"/>
+                                                            <rect key="frame" x="120" y="56" width="110" height="12"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="10"/>
                                                             <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="RPC Hidden Service:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bmo-Oz-X9F">
-                                                            <rect key="frame" x="8" y="23" width="106" height="12"/>
+                                                            <rect key="frame" x="8" y="42" width="106" height="12"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="12" id="0qu-gZ-T7c"/>
                                                                 <constraint firstAttribute="width" constant="106" id="Njz-A1-jYg"/>
@@ -3212,13 +3230,13 @@ You may export the public key descriptor at anytime but the 12 word recovery phr
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Node Wallet File:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WTY-QO-M67">
-                                                            <rect key="frame" x="8" y="37" width="86.5" height="12"/>
+                                                            <rect key="frame" x="8" y="56" width="86.5" height="12"/>
                                                             <fontDescription key="fontDescription" type="boldSystem" pointSize="10"/>
                                                             <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" tag="19" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="uf47hf*****ijef4.onion:1309" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="grH-6Y-3Ye">
-                                                            <rect key="frame" x="120" y="22" width="132" height="14.5"/>
+                                                            <rect key="frame" x="120" y="41" width="132" height="14.5"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="14.5" id="dfv-ti-aWf"/>
                                                             </constraints>
@@ -3226,20 +3244,28 @@ You may export the public key descriptor at anytime but the 12 word recovery phr
                                                             <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Node" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kNC-oy-Mhm">
-                                                            <rect key="frame" x="32" y="5.5" width="34.5" height="16"/>
-                                                            <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
-                                                            <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" tag="27" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Testing Node" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9iN-Rp-yFy">
-                                                            <rect key="frame" x="120" y="5" width="187" height="16"/>
+                                                            <rect key="frame" x="40" y="5" width="267" height="16"/>
                                                             <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
                                                             <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <button opaque="NO" tag="12" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hMg-mQ-qpp">
-                                                            <rect key="frame" x="279" y="13.5" width="28" height="28"/>
+                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="eye.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="LHX-l8-klg">
+                                                            <rect key="frame" x="8" y="26.5" width="24" height="13"/>
+                                                            <color key="tintColor" red="0.56318080459999997" green="0.56318080459999997" blue="0.56318080459999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="height" constant="16.5" id="CfG-Yf-bnr"/>
+                                                                <constraint firstAttribute="width" constant="24" id="E0A-4K-cte"/>
+                                                            </constraints>
+                                                        </imageView>
+                                                        <label opaque="NO" userInteractionEnabled="NO" tag="28" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="holds public keys 0 to 1999" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="U7S-4a-NWE">
+                                                            <rect key="frame" x="40" y="26" width="155.5" height="14.5"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                            <color key="textColor" red="0.57864717509999997" green="0.57864717509999997" blue="0.57864717509999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <button opaque="NO" tag="17" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hMg-mQ-qpp">
+                                                            <rect key="frame" x="279" y="41" width="28" height="28"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" constant="28" id="TYd-r6-Ltw"/>
                                                                 <constraint firstAttribute="height" constant="28" id="x2a-Tp-TXE"/>
@@ -3248,42 +3274,32 @@ You may export the public key descriptor at anytime but the 12 word recovery phr
                                                             <state key="normal" image="info.circle" catalog="system"/>
                                                         </button>
                                                     </subviews>
-                                                    <color key="backgroundColor" red="0.0" green="0.15797236686254543" blue="0.32751031089796967" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <color key="backgroundColor" red="0.1011690125" green="0.12519398330000001" blue="0.14604344960000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
+                                                        <constraint firstItem="U7S-4a-NWE" firstAttribute="leading" secondItem="9iN-Rp-yFy" secondAttribute="leading" id="2h6-o4-kn6"/>
                                                         <constraint firstAttribute="trailing" secondItem="hMg-mQ-qpp" secondAttribute="trailing" constant="7" id="4Pf-H0-75O"/>
                                                         <constraint firstItem="lvy-X2-fvE" firstAttribute="top" secondItem="7cK-yo-h4f" secondAttribute="top" constant="4" id="B8n-Cw-xkA"/>
-                                                        <constraint firstItem="hMg-mQ-qpp" firstAttribute="centerY" secondItem="7cK-yo-h4f" secondAttribute="centerY" id="BSV-o4-17c"/>
+                                                        <constraint firstItem="LHX-l8-klg" firstAttribute="leading" secondItem="7cK-yo-h4f" secondAttribute="leading" constant="8" id="O1l-VE-aOZ"/>
                                                         <constraint firstItem="ATh-mZ-6tE" firstAttribute="centerY" secondItem="WTY-QO-M67" secondAttribute="centerY" id="SGR-Xo-ToF"/>
+                                                        <constraint firstItem="bmo-Oz-X9F" firstAttribute="top" secondItem="LHX-l8-klg" secondAttribute="bottom" constant="0.5" id="Sid-CN-WTZ"/>
                                                         <constraint firstItem="WTY-QO-M67" firstAttribute="leading" secondItem="7cK-yo-h4f" secondAttribute="leading" constant="8" id="XMx-PX-dze"/>
+                                                        <constraint firstItem="U7S-4a-NWE" firstAttribute="centerY" secondItem="LHX-l8-klg" secondAttribute="centerY" id="awb-Hm-IFu"/>
                                                         <constraint firstItem="lvy-X2-fvE" firstAttribute="leading" secondItem="7cK-yo-h4f" secondAttribute="leading" constant="3" id="cu1-a4-hvA"/>
                                                         <constraint firstAttribute="trailing" secondItem="9iN-Rp-yFy" secondAttribute="trailing" constant="7" id="dhf-3q-VDe"/>
-                                                        <constraint firstItem="bmo-Oz-X9F" firstAttribute="top" secondItem="lvy-X2-fvE" secondAttribute="bottom" id="ft3-Hk-jH4"/>
                                                         <constraint firstItem="WTY-QO-M67" firstAttribute="top" secondItem="bmo-Oz-X9F" secondAttribute="bottom" constant="2" id="iDH-tI-TDo"/>
                                                         <constraint firstItem="ATh-mZ-6tE" firstAttribute="leading" secondItem="grH-6Y-3Ye" secondAttribute="leading" id="idQ-el-8Hi"/>
                                                         <constraint firstItem="grH-6Y-3Ye" firstAttribute="centerY" secondItem="bmo-Oz-X9F" secondAttribute="centerY" id="kDa-3l-3FN"/>
+                                                        <constraint firstAttribute="bottom" secondItem="hMg-mQ-qpp" secondAttribute="bottom" constant="5" id="lBC-7F-tQu"/>
                                                         <constraint firstItem="bmo-Oz-X9F" firstAttribute="leading" secondItem="7cK-yo-h4f" secondAttribute="leading" constant="8" id="mDW-Ai-rFT"/>
-                                                        <constraint firstAttribute="height" constant="55" id="oft-AV-aF7"/>
+                                                        <constraint firstAttribute="height" constant="74" id="oft-AV-aF7"/>
+                                                        <constraint firstItem="9iN-Rp-yFy" firstAttribute="leading" secondItem="lvy-X2-fvE" secondAttribute="trailing" constant="4" id="orx-mE-Qw0"/>
                                                         <constraint firstItem="grH-6Y-3Ye" firstAttribute="leading" secondItem="bmo-Oz-X9F" secondAttribute="trailing" constant="6" id="pfN-0j-2vF"/>
-                                                        <constraint firstItem="kNC-oy-Mhm" firstAttribute="centerY" secondItem="lvy-X2-fvE" secondAttribute="centerY" id="tud-gy-7bN"/>
+                                                        <constraint firstItem="LHX-l8-klg" firstAttribute="top" secondItem="lvy-X2-fvE" secondAttribute="bottom" constant="2" id="val-cH-Bqy"/>
                                                         <constraint firstItem="9iN-Rp-yFy" firstAttribute="top" secondItem="7cK-yo-h4f" secondAttribute="top" constant="5" id="wFB-GD-cVd"/>
-                                                        <constraint firstItem="grH-6Y-3Ye" firstAttribute="leading" secondItem="9iN-Rp-yFy" secondAttribute="leading" id="x7a-Kv-hA6"/>
-                                                        <constraint firstItem="kNC-oy-Mhm" firstAttribute="leading" secondItem="lvy-X2-fvE" secondAttribute="trailing" id="zfL-cp-wHt"/>
                                                     </constraints>
                                                 </view>
-                                                <label opaque="NO" userInteractionEnabled="NO" tag="11" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="P2WSH" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Rjr-gj-xPI">
-                                                    <rect key="frame" x="44" y="118" width="43" height="14.5"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                                    <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" tag="29" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Custom" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iCq-qO-kHT">
-                                                    <rect key="frame" x="285" y="118" width="44" height="14.5"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                                    <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" tag="1" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0.00000000" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XbB-vm-j8N">
-                                                    <rect key="frame" x="15" y="55" width="315" height="48"/>
+                                                    <rect key="frame" x="15" y="85" width="315" height="48"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="48" id="7uZ-mc-zjs"/>
                                                     </constraints>
@@ -3291,111 +3307,121 @@ You may export the public key descriptor at anytime but the 12 word recovery phr
                                                     <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <button opaque="NO" tag="12" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zTj-Pb-F3n">
-                                                    <rect key="frame" x="253" y="114" width="20" height="22"/>
-                                                    <color key="tintColor" red="0.037975538519999998" green="0.3805198669" blue="0.8801537156" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                    <state key="normal" image="pencil.circle" catalog="system"/>
-                                                </button>
                                                 <label opaque="NO" userInteractionEnabled="NO" tag="14" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2020-Feb-09 15:48" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="heW-e1-Z7l">
-                                                    <rect key="frame" x="56" y="103" width="87.5" height="11"/>
+                                                    <rect key="frame" x="56" y="133" width="87.5" height="11"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="9"/>
                                                     <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <button opaque="NO" tag="10" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vuq-o5-VbB">
-                                                    <rect key="frame" x="15" y="114" width="22" height="22"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="width" constant="22" id="GZS-5V-uZ6"/>
-                                                        <constraint firstAttribute="height" constant="22" id="ZiT-6L-Bdi"/>
-                                                    </constraints>
-                                                    <color key="tintColor" red="0.037975538519999998" green="0.3805198669" blue="0.8801537156" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                    <state key="normal" image="info.circle" catalog="system"/>
-                                                </button>
                                                 <switch opaque="NO" tag="2" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MI7-5S-Hm8">
-                                                    <rect key="frame" x="15" y="21" width="51" height="31"/>
+                                                    <rect key="frame" x="15" y="51" width="51" height="31"/>
                                                 </switch>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Created:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kXO-nW-Lzb">
-                                                    <rect key="frame" x="16" y="103" width="38" height="11"/>
+                                                    <rect key="frame" x="16" y="133" width="38" height="11"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="9"/>
                                                     <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" tag="24" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Active" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="x5l-4J-eDF">
-                                                    <rect key="frame" x="72" y="26.5" width="47.5" height="20.5"/>
+                                                    <rect key="frame" x="72" y="56.5" width="47.5" height="20.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" tag="13" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2020-Feb-09 15:48" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5Pt-N6-gH3">
-                                                    <rect key="frame" x="241.5" y="103" width="87.5" height="11"/>
+                                                    <rect key="frame" x="241.5" y="133" width="87.5" height="11"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="9"/>
                                                     <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Updated:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="H2O-8e-KbE">
-                                                    <rect key="frame" x="196.5" y="103" width="40.5" height="11"/>
+                                                    <rect key="frame" x="196.5" y="133" width="40.5" height="11"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="9"/>
                                                     <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <view clipsSubviews="YES" tag="22" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BKX-bZ-fhP">
-                                                    <rect key="frame" x="15" y="144" width="314" height="37"/>
-                                                    <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" tag="15" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1 Watch-only Testing Node" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b6y-YN-55v">
-                                                            <rect key="frame" x="31" y="4.5" width="152.5" height="14.5"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="height" constant="14.5" id="Q7p-mv-Gbl"/>
-                                                            </constraints>
-                                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                                            <color key="textColor" red="0.57864717509999997" green="0.57864717509999997" blue="0.57864717509999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" tag="28" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="public keys 0 to 1999" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="U7S-4a-NWE">
-                                                            <rect key="frame" x="30" y="19.5" width="121" height="14.5"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="height" constant="14.5" id="BxW-V6-DJi"/>
-                                                            </constraints>
-                                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                                            <color key="textColor" red="0.57864717509999997" green="0.57864717509999997" blue="0.57864717509999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
-                                                        <button opaque="NO" tag="17" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kpu-AH-GWw">
-                                                            <rect key="frame" x="278" y="4.5" width="28" height="28"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="width" constant="28" id="6Yf-NV-1aE"/>
-                                                                <constraint firstAttribute="height" constant="28" id="CFj-kh-VxZ"/>
-                                                            </constraints>
-                                                            <color key="tintColor" red="0.037975538519999998" green="0.3805198669" blue="0.8801537156" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                            <state key="normal" image="info.circle" catalog="system"/>
-                                                        </button>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="💻" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="apw-3W-VV7">
-                                                            <rect key="frame" x="255" y="10" width="20" height="17"/>
-                                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                            <nil key="textColor"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
-                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="eye" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="LHX-l8-klg">
-                                                            <rect key="frame" x="4" y="10" width="26" height="16.5"/>
-                                                            <color key="tintColor" red="0.56318080459999997" green="0.56318080459999997" blue="0.56318080459999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                        </imageView>
-                                                    </subviews>
-                                                    <color key="backgroundColor" red="0.0" green="0.15797236686254543" blue="0.32751031089796967" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" tag="8" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Testnet" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RxJ-Ev-lE6">
+                                                    <rect key="frame" x="255" y="53.5" width="75" height="26"/>
+                                                    <color key="backgroundColor" red="0.1169878617" green="0.13694825769999999" blue="0.15777918699999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="trailing" secondItem="kpu-AH-GWw" secondAttribute="trailing" constant="8" id="02h-5e-B42"/>
-                                                        <constraint firstAttribute="height" constant="37" id="5fB-qw-XT7"/>
-                                                        <constraint firstItem="b6y-YN-55v" firstAttribute="leading" secondItem="LHX-l8-klg" secondAttribute="trailing" constant="1" id="Jnc-SQ-daZ"/>
-                                                        <constraint firstItem="LHX-l8-klg" firstAttribute="centerY" secondItem="BKX-bZ-fhP" secondAttribute="centerY" id="UJB-xZ-nha"/>
-                                                        <constraint firstItem="apw-3W-VV7" firstAttribute="centerY" secondItem="BKX-bZ-fhP" secondAttribute="centerY" id="Yjo-bb-hdN"/>
-                                                        <constraint firstItem="kpu-AH-GWw" firstAttribute="centerY" secondItem="BKX-bZ-fhP" secondAttribute="centerY" id="bof-Jk-By0"/>
-                                                        <constraint firstItem="kpu-AH-GWw" firstAttribute="leading" secondItem="apw-3W-VV7" secondAttribute="trailing" constant="3" id="iAm-8l-Erh"/>
-                                                        <constraint firstItem="LHX-l8-klg" firstAttribute="leading" secondItem="BKX-bZ-fhP" secondAttribute="leading" constant="4" id="piQ-ZX-US6"/>
-                                                        <constraint firstItem="b6y-YN-55v" firstAttribute="top" secondItem="BKX-bZ-fhP" secondAttribute="top" constant="4.5" id="rqm-P5-LUC"/>
-                                                        <constraint firstItem="U7S-4a-NWE" firstAttribute="top" secondItem="b6y-YN-55v" secondAttribute="bottom" constant="0.5" id="wUA-eL-F2N"/>
-                                                        <constraint firstItem="U7S-4a-NWE" firstAttribute="leading" secondItem="LHX-l8-klg" secondAttribute="trailing" id="wwW-fz-1xR"/>
+                                                        <constraint firstAttribute="width" constant="75" id="0cG-BW-g1v"/>
+                                                        <constraint firstAttribute="height" constant="26" id="lOg-SZ-oik"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" type="system" weight="heavy" pointSize="12"/>
+                                                    <color key="textColor" systemColor="systemOrangeColor" red="1" green="0.58431372550000005" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <view tag="32" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3yo-oM-H8U">
+                                                    <rect key="frame" x="0.0" y="0.0" width="345" height="44"/>
+                                                    <subviews>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Cold Wallet" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wpC-FO-AQ7">
+                                                            <rect key="frame" x="37" y="15" width="74" height="15"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                            <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="snow" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="jhc-BJ-jgO">
+                                                            <rect key="frame" x="8" y="13.5" width="22" height="18"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="height" constant="21.5" id="3SP-gm-7bl"/>
+                                                                <constraint firstAttribute="width" constant="22" id="nXn-Iu-TvH"/>
+                                                            </constraints>
+                                                        </imageView>
+                                                        <stackView opaque="NO" contentMode="scaleToFill" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="3NT-Dl-JI7">
+                                                            <rect key="frame" x="137.5" y="11" width="70" height="22"/>
+                                                            <subviews>
+                                                                <button opaque="NO" tag="10" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vuq-o5-VbB">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="20" height="22"/>
+                                                                    <color key="tintColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                    <state key="normal" image="info.circle" catalog="system">
+                                                                        <color key="titleColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                    </state>
+                                                                </button>
+                                                                <label opaque="NO" userInteractionEnabled="NO" tag="11" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="P2WSH" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Rjr-gj-xPI">
+                                                                    <rect key="frame" x="27" y="0.0" width="43" height="22"/>
+                                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                                    <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                    <nil key="highlightedColor"/>
+                                                                </label>
+                                                            </subviews>
+                                                        </stackView>
+                                                        <label opaque="NO" userInteractionEnabled="NO" tag="29" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Custom" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iCq-qO-kHT">
+                                                            <rect key="frame" x="293" y="15" width="44" height="14.5"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                            <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <button opaque="NO" tag="12" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zTj-Pb-F3n">
+                                                            <rect key="frame" x="263" y="11" width="20" height="22"/>
+                                                            <color key="tintColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                            <state key="normal" image="pencil.circle" catalog="system">
+                                                                <color key="titleColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                            </state>
+                                                        </button>
+                                                    </subviews>
+                                                    <color key="backgroundColor" red="0.0" green="0.12964066860000001" blue="0.2750228643" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <constraints>
+                                                        <constraint firstItem="3NT-Dl-JI7" firstAttribute="centerX" secondItem="3yo-oM-H8U" secondAttribute="centerX" id="8eV-Ic-u7B"/>
+                                                        <constraint firstAttribute="trailing" secondItem="iCq-qO-kHT" secondAttribute="trailing" constant="8" id="DEl-cx-CIQ"/>
+                                                        <constraint firstItem="wpC-FO-AQ7" firstAttribute="leading" secondItem="jhc-BJ-jgO" secondAttribute="trailing" constant="7" id="DjU-ca-eE9"/>
+                                                        <constraint firstItem="jhc-BJ-jgO" firstAttribute="leading" secondItem="3yo-oM-H8U" secondAttribute="leading" constant="8" id="Iy4-Tw-UOE"/>
+                                                        <constraint firstItem="zTj-Pb-F3n" firstAttribute="centerY" secondItem="3yo-oM-H8U" secondAttribute="centerY" id="KD6-7Q-zwj"/>
+                                                        <constraint firstAttribute="height" constant="44" id="N5T-xw-euJ"/>
+                                                        <constraint firstItem="iCq-qO-kHT" firstAttribute="centerY" secondItem="3yo-oM-H8U" secondAttribute="centerY" id="asO-q2-rjy"/>
+                                                        <constraint firstItem="wpC-FO-AQ7" firstAttribute="centerY" secondItem="3yo-oM-H8U" secondAttribute="centerY" id="gUG-UU-XXV"/>
+                                                        <constraint firstItem="jhc-BJ-jgO" firstAttribute="centerY" secondItem="3yo-oM-H8U" secondAttribute="centerY" id="iuw-x8-XSu"/>
+                                                        <constraint firstItem="iCq-qO-kHT" firstAttribute="leading" secondItem="zTj-Pb-F3n" secondAttribute="trailing" constant="10" id="kYv-zi-pVk"/>
+                                                        <constraint firstItem="3NT-Dl-JI7" firstAttribute="centerY" secondItem="3yo-oM-H8U" secondAttribute="centerY" id="mQf-LR-iYU"/>
                                                     </constraints>
                                                 </view>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Node:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FGC-6L-vwx">
+                                                    <rect key="frame" x="16" y="149" width="30.5" height="12"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="10"/>
+                                                    <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
                                                 <view clipsSubviews="YES" tag="25" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="W1t-FH-89R">
-                                                    <rect key="frame" x="16" y="252" width="313" height="38"/>
+                                                    <rect key="frame" x="16" y="246" width="313" height="38"/>
                                                     <subviews>
                                                         <stackView opaque="NO" tag="25" contentMode="scaleToFill" distribution="equalSpacing" spacing="11" translatesAutoresizingMaskIntoConstraints="NO" id="3GT-EX-m02">
                                                             <rect key="frame" x="8" y="6" width="298" height="26"/>
@@ -3446,184 +3472,185 @@ You may export the public key descriptor at anytime but the 12 word recovery phr
                                                         <constraint firstAttribute="height" constant="38" id="d17-jJ-FcF"/>
                                                     </constraints>
                                                 </view>
-                                                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" tag="8" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Testnet" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RxJ-Ev-lE6">
-                                                    <rect key="frame" x="255" y="23.5" width="75" height="26"/>
-                                                    <color key="backgroundColor" red="0.0" green="0.1521064043" blue="0.3307800293" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="width" constant="75" id="0cG-BW-g1v"/>
-                                                        <constraint firstAttribute="height" constant="26" id="lOg-SZ-oik"/>
-                                                    </constraints>
-                                                    <fontDescription key="fontDescription" type="system" weight="heavy" pointSize="12"/>
-                                                    <color key="textColor" systemColor="systemOrangeColor" red="1" green="0.58431372550000005" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
                                             </subviews>
+                                            <color key="backgroundColor" red="0.085763759910000001" green="0.10179834810000001" blue="0.1143214479" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <constraints>
-                                                <constraint firstAttribute="trailingMargin" secondItem="BKX-bZ-fhP" secondAttribute="trailing" constant="1" id="1eG-A9-Y8w"/>
-                                                <constraint firstItem="Rjr-gj-xPI" firstAttribute="centerY" secondItem="vuq-o5-VbB" secondAttribute="centerY" id="2mf-oC-Bzb"/>
+                                                <constraint firstItem="3yo-oM-H8U" firstAttribute="top" secondItem="85P-mu-gZ2" secondAttribute="top" id="3tx-EJ-IDu"/>
                                                 <constraint firstItem="XbB-vm-j8N" firstAttribute="leading" secondItem="85P-mu-gZ2" secondAttribute="leadingMargin" id="5QX-Gx-GVg"/>
                                                 <constraint firstAttribute="trailing" secondItem="XbB-vm-j8N" secondAttribute="trailing" constant="15" id="7aR-GH-GJo"/>
-                                                <constraint firstItem="BKX-bZ-fhP" firstAttribute="leading" secondItem="85P-mu-gZ2" secondAttribute="leadingMargin" id="9Et-7y-0Cl"/>
                                                 <constraint firstItem="W1t-FH-89R" firstAttribute="leading" secondItem="85P-mu-gZ2" secondAttribute="leading" constant="16" id="9FM-5Q-cNB"/>
                                                 <constraint firstItem="kXO-nW-Lzb" firstAttribute="leading" secondItem="85P-mu-gZ2" secondAttribute="leading" constant="16" id="9gb-JH-Hmo"/>
+                                                <constraint firstAttribute="bottom" secondItem="W1t-FH-89R" secondAttribute="bottom" constant="10" id="BcB-f1-DEE"/>
+                                                <constraint firstItem="FGC-6L-vwx" firstAttribute="top" secondItem="kXO-nW-Lzb" secondAttribute="bottom" constant="5" id="CHI-Pm-kVJ"/>
                                                 <constraint firstItem="RxJ-Ev-lE6" firstAttribute="centerY" secondItem="x5l-4J-eDF" secondAttribute="centerY" id="DQy-D9-7tl"/>
                                                 <constraint firstItem="kXO-nW-Lzb" firstAttribute="top" secondItem="XbB-vm-j8N" secondAttribute="bottom" id="Ef7-ej-E7B"/>
-                                                <constraint firstItem="Rjr-gj-xPI" firstAttribute="leading" secondItem="vuq-o5-VbB" secondAttribute="trailing" constant="7" id="EjV-86-lMR"/>
-                                                <constraint firstItem="7cK-yo-h4f" firstAttribute="top" secondItem="BKX-bZ-fhP" secondAttribute="bottom" constant="8" id="Ey0-R3-v97"/>
                                                 <constraint firstItem="x5l-4J-eDF" firstAttribute="leading" secondItem="MI7-5S-Hm8" secondAttribute="trailing" constant="8" id="F2V-wL-LaT"/>
                                                 <constraint firstItem="7cK-yo-h4f" firstAttribute="trailing" secondItem="85P-mu-gZ2" secondAttribute="trailingMargin" constant="-1" id="Fkx-8E-izv"/>
                                                 <constraint firstAttribute="trailing" secondItem="W1t-FH-89R" secondAttribute="trailing" constant="16" id="GI8-If-ZNe"/>
                                                 <constraint firstItem="5Pt-N6-gH3" firstAttribute="centerY" secondItem="H2O-8e-KbE" secondAttribute="centerY" id="GkR-YQ-BjP"/>
                                                 <constraint firstItem="heW-e1-Z7l" firstAttribute="leading" secondItem="kXO-nW-Lzb" secondAttribute="trailing" constant="2" id="HGT-Hg-kdT"/>
-                                                <constraint firstItem="iCq-qO-kHT" firstAttribute="leading" secondItem="zTj-Pb-F3n" secondAttribute="trailing" constant="12" id="MR7-zZ-gWZ"/>
+                                                <constraint firstItem="FGC-6L-vwx" firstAttribute="leading" secondItem="85P-mu-gZ2" secondAttribute="leadingMargin" constant="1" id="Qbc-xp-jhi"/>
+                                                <constraint firstItem="3yo-oM-H8U" firstAttribute="leading" secondItem="85P-mu-gZ2" secondAttribute="leading" id="SQa-Sb-2Hs"/>
                                                 <constraint firstItem="5Pt-N6-gH3" firstAttribute="leading" secondItem="H2O-8e-KbE" secondAttribute="trailing" constant="4.5" id="Sp4-1r-AWZ"/>
-                                                <constraint firstItem="MI7-5S-Hm8" firstAttribute="top" secondItem="85P-mu-gZ2" secondAttribute="topMargin" constant="10" id="UJb-ds-qmG"/>
                                                 <constraint firstItem="XbB-vm-j8N" firstAttribute="top" secondItem="MI7-5S-Hm8" secondAttribute="bottom" constant="3" id="WWi-FR-Y28"/>
                                                 <constraint firstItem="7cK-yo-h4f" firstAttribute="leading" secondItem="85P-mu-gZ2" secondAttribute="leadingMargin" id="WlC-8N-hf6"/>
                                                 <constraint firstItem="H2O-8e-KbE" firstAttribute="centerY" secondItem="heW-e1-Z7l" secondAttribute="centerY" id="WpC-QF-y8M"/>
                                                 <constraint firstItem="RxJ-Ev-lE6" firstAttribute="trailing" secondItem="85P-mu-gZ2" secondAttribute="trailingMargin" id="XDV-tl-LBw"/>
-                                                <constraint firstItem="W1t-FH-89R" firstAttribute="bottom" secondItem="85P-mu-gZ2" secondAttribute="bottomMargin" constant="-9" id="c9X-1M-qNi"/>
-                                                <constraint firstItem="BKX-bZ-fhP" firstAttribute="top" secondItem="zTj-Pb-F3n" secondAttribute="bottom" constant="8" id="dh1-bM-fO7"/>
+                                                <constraint firstItem="W1t-FH-89R" firstAttribute="bottom" secondItem="85P-mu-gZ2" secondAttribute="bottomMargin" constant="1" id="c9X-1M-qNi"/>
                                                 <constraint firstAttribute="trailing" secondItem="5Pt-N6-gH3" secondAttribute="trailing" constant="16" id="eXh-hO-dgc"/>
-                                                <constraint firstItem="vuq-o5-VbB" firstAttribute="leading" secondItem="85P-mu-gZ2" secondAttribute="leadingMargin" id="fyu-jE-8Bo"/>
-                                                <constraint firstAttribute="trailingMargin" secondItem="iCq-qO-kHT" secondAttribute="trailing" constant="1" id="gjB-cD-Hlm"/>
                                                 <constraint firstItem="MI7-5S-Hm8" firstAttribute="leading" secondItem="85P-mu-gZ2" secondAttribute="leadingMargin" id="gyQ-b2-gnC"/>
-                                                <constraint firstItem="iCq-qO-kHT" firstAttribute="centerY" secondItem="Rjr-gj-xPI" secondAttribute="centerY" id="hNH-rT-rSd"/>
-                                                <constraint firstAttribute="trailingMargin" secondItem="BKX-bZ-fhP" secondAttribute="trailing" constant="1" id="hfv-CN-oRk"/>
                                                 <constraint firstItem="5Pt-N6-gH3" firstAttribute="centerY" secondItem="heW-e1-Z7l" secondAttribute="centerY" id="otN-xT-iqm"/>
                                                 <constraint firstItem="W1t-FH-89R" firstAttribute="top" secondItem="7cK-yo-h4f" secondAttribute="bottom" constant="8" id="qdV-ie-Yhr"/>
                                                 <constraint firstItem="7cK-yo-h4f" firstAttribute="leading" secondItem="85P-mu-gZ2" secondAttribute="leadingMargin" id="qp2-zN-x7J"/>
-                                                <constraint firstItem="vuq-o5-VbB" firstAttribute="top" secondItem="kXO-nW-Lzb" secondAttribute="bottom" id="r3q-f3-4Do"/>
-                                                <constraint firstItem="zTj-Pb-F3n" firstAttribute="centerY" secondItem="Rjr-gj-xPI" secondAttribute="centerY" id="rm5-df-zO8"/>
                                                 <constraint firstItem="heW-e1-Z7l" firstAttribute="centerY" secondItem="kXO-nW-Lzb" secondAttribute="centerY" id="tCs-hB-nc6"/>
                                                 <constraint firstAttribute="trailingMargin" secondItem="7cK-yo-h4f" secondAttribute="trailing" constant="1" id="tnk-fr-KxY"/>
+                                                <constraint firstItem="MI7-5S-Hm8" firstAttribute="top" secondItem="3yo-oM-H8U" secondAttribute="bottom" constant="7" id="wgC-X3-QVU"/>
+                                                <constraint firstAttribute="trailing" secondItem="3yo-oM-H8U" secondAttribute="trailing" id="xFc-6V-5hA"/>
                                                 <constraint firstItem="7cK-yo-h4f" firstAttribute="trailing" secondItem="85P-mu-gZ2" secondAttribute="trailingMargin" constant="-1" id="xW2-Sq-AiQ"/>
                                                 <constraint firstItem="x5l-4J-eDF" firstAttribute="centerY" secondItem="MI7-5S-Hm8" secondAttribute="centerY" id="zY5-4e-73h"/>
                                             </constraints>
                                         </tableViewCellContentView>
-                                        <color key="backgroundColor" red="0.0" green="0.13545817230000001" blue="0.28083359769999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="backgroundColor" red="0.070211939510000002" green="0.082253791389999997" blue="0.090610332789999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="singleSigWalletCell" rowHeight="370" id="GZc-Lm-9ch">
-                                        <rect key="frame" x="15" y="365.5" width="345" height="370"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="singleSigWalletCell" rowHeight="363" id="GZc-Lm-9ch">
+                                        <rect key="frame" x="15" y="349.5" width="345" height="363"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="GZc-Lm-9ch" id="nN1-0D-mSU">
-                                            <rect key="frame" x="0.0" y="0.0" width="345" height="370"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="345" height="363"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <view clipsSubviews="YES" tag="26" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Mus-be-FaA">
-                                                    <rect key="frame" x="15" y="249" width="315" height="55"/>
-                                                    <subviews>
-                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="desktopcomputer" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="3Cs-N1-Juh">
-                                                            <rect key="frame" x="3" y="4.5" width="29" height="18"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="height" constant="19" id="Cuh-Ps-tDg"/>
-                                                                <constraint firstAttribute="width" constant="29" id="Hep-0H-OHF"/>
-                                                            </constraints>
-                                                        </imageView>
-                                                        <label opaque="NO" userInteractionEnabled="NO" tag="20" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="uhRD45u_StandUp.dat" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LpX-Z8-tmr">
-                                                            <rect key="frame" x="120" y="37" width="110" height="12"/>
-                                                            <fontDescription key="fontDescription" type="system" pointSize="10"/>
-                                                            <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="RPC Hidden Service:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="car-yr-b08">
-                                                            <rect key="frame" x="8" y="23" width="106" height="12"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="width" constant="106" id="FIK-y9-2Jh"/>
-                                                                <constraint firstAttribute="height" constant="12" id="m84-HH-tRS"/>
-                                                            </constraints>
-                                                            <fontDescription key="fontDescription" type="boldSystem" pointSize="10"/>
-                                                            <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Node Wallet File:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="g8x-Ld-Ezw">
-                                                            <rect key="frame" x="8" y="37" width="86.5" height="12"/>
-                                                            <fontDescription key="fontDescription" type="boldSystem" pointSize="10"/>
-                                                            <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
-                                                        <button opaque="NO" tag="12" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ow1-MZ-DSx">
-                                                            <rect key="frame" x="279" y="13.5" width="28" height="28"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="height" constant="28" id="reF-wW-LEa"/>
-                                                                <constraint firstAttribute="width" constant="28" id="zrg-Ma-OHQ"/>
-                                                            </constraints>
-                                                            <color key="tintColor" red="0.037975538519999998" green="0.3805198669" blue="0.8801537156" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                            <state key="normal" image="info.circle" catalog="system"/>
-                                                        </button>
-                                                        <label opaque="NO" userInteractionEnabled="NO" tag="19" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="uf47hf*****ijef4.onion:1309" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ev4-Ba-BNf">
-                                                            <rect key="frame" x="120" y="22" width="132" height="14.5"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="height" constant="14.5" id="5cR-FM-OYq"/>
-                                                            </constraints>
-                                                            <fontDescription key="fontDescription" type="system" pointSize="10"/>
-                                                            <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Node" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hSN-ag-v89">
-                                                            <rect key="frame" x="32" y="5.5" width="34.5" height="16"/>
-                                                            <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
-                                                            <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" tag="27" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Testing Node" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lGp-Ln-vMg">
-                                                            <rect key="frame" x="120" y="5" width="187" height="16"/>
-                                                            <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
-                                                            <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
-                                                    </subviews>
-                                                    <color key="backgroundColor" red="0.1432691574537093" green="0.17390265680334469" blue="0.19676344636040599" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                    <constraints>
-                                                        <constraint firstItem="g8x-Ld-Ezw" firstAttribute="top" secondItem="car-yr-b08" secondAttribute="bottom" constant="2" id="66n-Dg-o7p"/>
-                                                        <constraint firstItem="3Cs-N1-Juh" firstAttribute="top" secondItem="Mus-be-FaA" secondAttribute="top" constant="4" id="7Jy-vE-KhN"/>
-                                                        <constraint firstAttribute="trailing" secondItem="ow1-MZ-DSx" secondAttribute="trailing" constant="8" id="8gl-hK-itw"/>
-                                                        <constraint firstItem="ev4-Ba-BNf" firstAttribute="leading" secondItem="car-yr-b08" secondAttribute="trailing" constant="6" id="Ejf-nm-mYA"/>
-                                                        <constraint firstItem="LpX-Z8-tmr" firstAttribute="centerY" secondItem="g8x-Ld-Ezw" secondAttribute="centerY" id="G5x-k3-tgS"/>
-                                                        <constraint firstItem="ev4-Ba-BNf" firstAttribute="centerY" secondItem="car-yr-b08" secondAttribute="centerY" id="KDU-5j-hq8"/>
-                                                        <constraint firstAttribute="trailing" secondItem="lGp-Ln-vMg" secondAttribute="trailing" constant="8" id="Pb7-0s-cYw"/>
-                                                        <constraint firstItem="ev4-Ba-BNf" firstAttribute="leading" secondItem="lGp-Ln-vMg" secondAttribute="leading" id="UVp-8F-f67"/>
-                                                        <constraint firstItem="hSN-ag-v89" firstAttribute="leading" secondItem="3Cs-N1-Juh" secondAttribute="trailing" id="V7h-xu-BtP"/>
-                                                        <constraint firstItem="ow1-MZ-DSx" firstAttribute="centerY" secondItem="Mus-be-FaA" secondAttribute="centerY" id="VaY-LR-aNr"/>
-                                                        <constraint firstItem="car-yr-b08" firstAttribute="leading" secondItem="Mus-be-FaA" secondAttribute="leading" constant="8" id="hrQ-Et-b1Y"/>
-                                                        <constraint firstItem="hSN-ag-v89" firstAttribute="centerY" secondItem="3Cs-N1-Juh" secondAttribute="centerY" id="iSb-X9-1fT"/>
-                                                        <constraint firstItem="lGp-Ln-vMg" firstAttribute="top" secondItem="Mus-be-FaA" secondAttribute="top" constant="5" id="nrA-d5-v8A"/>
-                                                        <constraint firstItem="3Cs-N1-Juh" firstAttribute="leading" secondItem="Mus-be-FaA" secondAttribute="leading" constant="3" id="nwu-Xj-fto"/>
-                                                        <constraint firstAttribute="height" constant="55" id="qNv-yN-wVQ"/>
-                                                        <constraint firstItem="car-yr-b08" firstAttribute="top" secondItem="3Cs-N1-Juh" secondAttribute="bottom" id="rUi-q3-zda"/>
-                                                        <constraint firstItem="LpX-Z8-tmr" firstAttribute="leading" secondItem="ev4-Ba-BNf" secondAttribute="leading" id="uHL-Ae-M4f"/>
-                                                        <constraint firstItem="g8x-Ld-Ezw" firstAttribute="leading" secondItem="Mus-be-FaA" secondAttribute="leading" constant="8" id="x0E-3s-aK6"/>
-                                                    </constraints>
-                                                </view>
-                                                <label opaque="NO" userInteractionEnabled="NO" tag="11" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="BIP84" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7jg-Bo-IWL">
-                                                    <rect key="frame" x="44" y="118" width="34.5" height="14.5"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                                    <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Single Sig" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yya-jz-VRS">
-                                                    <rect key="frame" x="272.5" y="118" width="56.5" height="14.5"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                                    <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Signer:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vxO-CT-ic3">
-                                                    <rect key="frame" x="16" y="140" width="37.5" height="12"/>
-                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="10"/>
-                                                    <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" tag="1" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0.00000000" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6Sm-zd-H8y">
-                                                    <rect key="frame" x="15" y="55" width="315" height="48"/>
+                                                    <rect key="frame" x="15" y="88" width="315" height="48"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="height" constant="48" id="BtV-bd-ifa"/>
+                                                        <constraint firstAttribute="height" constant="48" id="yEh-ZL-k6D"/>
                                                     </constraints>
                                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="46"/>
                                                     <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" tag="14" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2020-Feb-09 15:48" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TQL-WW-Jpr">
+                                                    <rect key="frame" x="60" y="136" width="87.5" height="11"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="9"/>
+                                                    <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <switch opaque="NO" tag="2" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="SPc-CN-QXX">
+                                                    <rect key="frame" x="15" y="52" width="51" height="31"/>
+                                                </switch>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Created:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DLd-eo-yhH">
+                                                    <rect key="frame" x="14" y="136" width="38" height="11"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="9"/>
+                                                    <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" tag="24" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Active" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tdt-Ap-iVt">
+                                                    <rect key="frame" x="72" y="57.5" width="47.5" height="20.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" tag="13" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2020-Feb-09 15:48" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kYv-xd-YpP">
+                                                    <rect key="frame" x="240" y="136" width="87.5" height="11"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="9"/>
+                                                    <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Updated:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gEN-a7-pZj">
+                                                    <rect key="frame" x="191" y="136" width="40.5" height="11"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="9"/>
+                                                    <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" tag="8" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Testnet" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dOn-Dy-2vG">
+                                                    <rect key="frame" x="255" y="56" width="75" height="23"/>
+                                                    <color key="backgroundColor" red="0.11157282175978181" green="0.14015675464891095" blue="0.16410052308781731" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="75" id="WEP-RR-sQl"/>
+                                                        <constraint firstAttribute="height" constant="23" id="qlU-TU-axm"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" type="system" weight="heavy" pointSize="12"/>
+                                                    <color key="textColor" systemColor="systemOrangeColor" red="1" green="0.58431372550000005" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <view tag="32" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7yp-J1-Thl">
+                                                    <rect key="frame" x="0.0" y="0.0" width="345" height="44"/>
+                                                    <subviews>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Single Sig" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yya-jz-VRS">
+                                                            <rect key="frame" x="280" y="15" width="56.5" height="14.5"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                            <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hot Wallet" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2cM-ZB-Hnc">
+                                                            <rect key="frame" x="38" y="15" width="59" height="14.5"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                            <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <button opaque="NO" tag="12" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ciE-Bi-Iml">
+                                                            <rect key="frame" x="252" y="11" width="20" height="22"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="height" constant="22" id="Jde-Lt-zIA"/>
+                                                                <constraint firstAttribute="width" constant="20" id="TiX-WE-1v5"/>
+                                                            </constraints>
+                                                            <color key="tintColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                            <state key="normal" image="pencil.circle" catalog="system"/>
+                                                        </button>
+                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flame" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="1Y4-I8-ZHa">
+                                                            <rect key="frame" x="8" y="10.5" width="22" height="22"/>
+                                                            <color key="tintColor" systemColor="systemRedColor" red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="width" constant="22" id="6fZ-yf-aon"/>
+                                                                <constraint firstAttribute="height" constant="21.5" id="dmd-qv-qpq"/>
+                                                            </constraints>
+                                                        </imageView>
+                                                        <stackView opaque="NO" contentMode="scaleToFill" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="ox5-Za-y4T">
+                                                            <rect key="frame" x="141" y="11" width="63.5" height="22"/>
+                                                            <subviews>
+                                                                <button opaque="NO" tag="10" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="g94-fh-bhc">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="22" height="22"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="width" constant="22" id="EFV-Tl-3rQ"/>
+                                                                        <constraint firstAttribute="height" constant="22" id="RDj-Lp-oDy"/>
+                                                                    </constraints>
+                                                                    <color key="tintColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                    <state key="normal" image="info.circle" catalog="system"/>
+                                                                </button>
+                                                                <label opaque="NO" userInteractionEnabled="NO" tag="11" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="BIP84" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7jg-Bo-IWL">
+                                                                    <rect key="frame" x="29" y="0.0" width="34.5" height="22"/>
+                                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                                    <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                    <nil key="highlightedColor"/>
+                                                                </label>
+                                                            </subviews>
+                                                            <constraints>
+                                                                <constraint firstAttribute="width" constant="63.5" id="caN-K3-a8E"/>
+                                                            </constraints>
+                                                        </stackView>
+                                                    </subviews>
+                                                    <color key="backgroundColor" red="0.0" green="0.16319443578768075" blue="0.33833677030456855" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <constraints>
+                                                        <constraint firstItem="1Y4-I8-ZHa" firstAttribute="centerY" secondItem="7yp-J1-Thl" secondAttribute="centerY" id="6R3-K4-Hk4"/>
+                                                        <constraint firstAttribute="trailing" secondItem="yya-jz-VRS" secondAttribute="trailing" constant="8.5" id="Dsf-A5-AqW"/>
+                                                        <constraint firstItem="2cM-ZB-Hnc" firstAttribute="centerY" secondItem="7yp-J1-Thl" secondAttribute="centerY" id="Dvj-UT-O8N"/>
+                                                        <constraint firstAttribute="height" constant="44" id="EnW-HB-qVW"/>
+                                                        <constraint firstItem="1Y4-I8-ZHa" firstAttribute="leading" secondItem="7yp-J1-Thl" secondAttribute="leading" constant="8" id="GVO-Qs-hi9"/>
+                                                        <constraint firstItem="ox5-Za-y4T" firstAttribute="centerY" secondItem="7yp-J1-Thl" secondAttribute="centerY" id="H1C-tC-Iav"/>
+                                                        <constraint firstItem="yya-jz-VRS" firstAttribute="centerY" secondItem="7yp-J1-Thl" secondAttribute="centerY" id="SU9-er-6T9"/>
+                                                        <constraint firstItem="ox5-Za-y4T" firstAttribute="centerX" secondItem="7yp-J1-Thl" secondAttribute="centerX" id="VkP-LK-pbY"/>
+                                                        <constraint firstItem="2cM-ZB-Hnc" firstAttribute="leading" secondItem="1Y4-I8-ZHa" secondAttribute="trailing" constant="8" id="glI-hk-YOj"/>
+                                                        <constraint firstItem="yya-jz-VRS" firstAttribute="leading" secondItem="ciE-Bi-Iml" secondAttribute="trailing" constant="8" id="veW-J2-w5t"/>
+                                                        <constraint firstItem="ciE-Bi-Iml" firstAttribute="centerY" secondItem="7yp-J1-Thl" secondAttribute="centerY" id="yXl-1l-HSo"/>
+                                                    </constraints>
+                                                </view>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Signer:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vxO-CT-ic3">
+                                                    <rect key="frame" x="15" y="149" width="37.5" height="12"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="10"/>
+                                                    <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
                                                 <view clipsSubviews="YES" tag="21" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AMk-q2-GQu">
-                                                    <rect key="frame" x="16" y="159" width="314" height="37"/>
+                                                    <rect key="frame" x="15" y="165" width="315" height="37"/>
                                                     <subviews>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="key.png" translatesAutoresizingMaskIntoConstraints="NO" id="dsR-fd-JD7">
                                                             <rect key="frame" x="4" y="4" width="20" height="15"/>
@@ -3679,37 +3706,68 @@ You may export the public key descriptor at anytime but the 12 word recovery phr
                                                             <state key="normal" image="info.circle" catalog="system"/>
                                                         </button>
                                                     </subviews>
-                                                    <color key="backgroundColor" red="0.1432691574537093" green="0.17390265680334469" blue="0.19676344636040599" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <color key="backgroundColor" red="0.11157282175978181" green="0.14015675464891095" blue="0.16410052308781731" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
-                                                        <constraint firstItem="Fds-1S-xmg" firstAttribute="centerY" secondItem="AMk-q2-GQu" secondAttribute="centerY" id="1U0-6C-W1n"/>
-                                                        <constraint firstItem="GYH-38-DIo" firstAttribute="leading" secondItem="AMk-q2-GQu" secondAttribute="leading" constant="4" id="CVt-bG-Cza"/>
                                                         <constraint firstItem="pyd-Ka-tcK" firstAttribute="leading" secondItem="dsR-fd-JD7" secondAttribute="trailing" constant="5" id="Dyv-cy-93U"/>
-                                                        <constraint firstItem="dsR-fd-JD7" firstAttribute="top" secondItem="AMk-q2-GQu" secondAttribute="top" constant="4" id="JbQ-cJ-lx1"/>
+                                                        <constraint firstAttribute="height" constant="37" id="FTw-bS-4Ev"/>
+                                                        <constraint firstItem="jsT-JM-dwh" firstAttribute="centerY" secondItem="AMk-q2-GQu" secondAttribute="centerY" id="GNk-79-cyF"/>
+                                                        <constraint firstAttribute="bottom" secondItem="GYH-38-DIo" secondAttribute="bottom" constant="3" id="Izd-hW-mtQ"/>
                                                         <constraint firstItem="Rv1-3Q-zmL" firstAttribute="leading" secondItem="GYH-38-DIo" secondAttribute="trailing" constant="6" id="MTh-Q0-kuQ"/>
                                                         <constraint firstItem="GYH-38-DIo" firstAttribute="top" secondItem="dsR-fd-JD7" secondAttribute="bottom" id="URf-Qi-t3E"/>
                                                         <constraint firstItem="jsT-JM-dwh" firstAttribute="leading" secondItem="Fds-1S-xmg" secondAttribute="trailing" constant="4" id="VNj-zT-vBV"/>
-                                                        <constraint firstAttribute="height" constant="37" id="VmN-mT-7aT"/>
-                                                        <constraint firstAttribute="trailing" secondItem="jsT-JM-dwh" secondAttribute="trailing" constant="8" id="XH3-C5-iN5"/>
                                                         <constraint firstItem="pyd-Ka-tcK" firstAttribute="centerY" secondItem="dsR-fd-JD7" secondAttribute="centerY" id="Zfb-G7-RKn"/>
-                                                        <constraint firstItem="dsR-fd-JD7" firstAttribute="leading" secondItem="AMk-q2-GQu" secondAttribute="leading" constant="4" id="vJh-Vy-Y23"/>
+                                                        <constraint firstItem="Fds-1S-xmg" firstAttribute="centerY" secondItem="AMk-q2-GQu" secondAttribute="centerY" id="acc-s9-4hI"/>
+                                                        <constraint firstAttribute="trailing" secondItem="jsT-JM-dwh" secondAttribute="trailing" constant="9" id="cpr-q0-XIy"/>
+                                                        <constraint firstItem="dsR-fd-JD7" firstAttribute="leading" secondItem="AMk-q2-GQu" secondAttribute="leading" constant="4" id="dfK-7Y-Ebn"/>
+                                                        <constraint firstItem="GYH-38-DIo" firstAttribute="leading" secondItem="AMk-q2-GQu" secondAttribute="leading" constant="4" id="hvF-ZG-W2i"/>
+                                                        <constraint firstItem="dsR-fd-JD7" firstAttribute="top" secondItem="AMk-q2-GQu" secondAttribute="top" constant="4" id="lLX-G7-mNy"/>
                                                         <constraint firstItem="Rv1-3Q-zmL" firstAttribute="centerY" secondItem="GYH-38-DIo" secondAttribute="centerY" id="whB-Uq-CQi"/>
-                                                        <constraint firstItem="jsT-JM-dwh" firstAttribute="centerY" secondItem="AMk-q2-GQu" secondAttribute="centerY" id="ygy-JP-Iil"/>
                                                     </constraints>
                                                 </view>
-                                                <view clipsSubviews="YES" tag="22" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="z3r-1y-FSf">
-                                                    <rect key="frame" x="16" y="204" width="314" height="37"/>
+                                                <view clipsSubviews="YES" tag="26" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Mus-be-FaA">
+                                                    <rect key="frame" x="15" y="227" width="315" height="84"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" tag="15" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1 Watch-only Testing Node" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n61-Zn-aDm">
-                                                            <rect key="frame" x="31" y="4.5" width="152.5" height="14.5"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="height" constant="14.5" id="5PK-Sh-Mih"/>
-                                                            </constraints>
-                                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                                            <color key="textColor" red="0.57864717509999997" green="0.57864717509999997" blue="0.57864717509999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" tag="20" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="uhRD45u_StandUp.dat" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LpX-Z8-tmr">
+                                                            <rect key="frame" x="120" y="66" width="110" height="12"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="10"/>
+                                                            <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="public keys m'/84'/1'/0'/0/0 to /1999" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i60-gh-Nax">
-                                                            <rect key="frame" x="30" y="19.5" width="203.5" height="14.5"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="RPC Hidden Service:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="car-yr-b08">
+                                                            <rect key="frame" x="8" y="52" width="106" height="12"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="width" constant="106" id="FIK-y9-2Jh"/>
+                                                                <constraint firstAttribute="height" constant="12" id="m84-HH-tRS"/>
+                                                            </constraints>
+                                                            <fontDescription key="fontDescription" type="boldSystem" pointSize="10"/>
+                                                            <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Node Wallet File:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="g8x-Ld-Ezw">
+                                                            <rect key="frame" x="8" y="66" width="86.5" height="12"/>
+                                                            <fontDescription key="fontDescription" type="boldSystem" pointSize="10"/>
+                                                            <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <label opaque="NO" userInteractionEnabled="NO" tag="19" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="uf47hf*****ijef4.onion:1309" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ev4-Ba-BNf">
+                                                            <rect key="frame" x="120" y="51" width="132" height="14.5"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="height" constant="14.5" id="5cR-FM-OYq"/>
+                                                            </constraints>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="10"/>
+                                                            <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="eye.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="czI-ur-V3d">
+                                                            <rect key="frame" x="8" y="27.5" width="20" height="14"/>
+                                                            <color key="tintColor" red="0.56318080459999997" green="0.56318080459999997" blue="0.56318080459999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="height" constant="17.5" id="7Bl-bm-waF"/>
+                                                                <constraint firstAttribute="width" constant="20" id="938-fY-TFG"/>
+                                                            </constraints>
+                                                        </imageView>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="holds public keys m'/84'/1'/0'/0/0 to /1999" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i60-gh-Nax">
+                                                            <rect key="frame" x="36" y="27.5" width="237.5" height="14.5"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="14.5" id="Ur2-EI-36j"/>
                                                             </constraints>
@@ -3717,93 +3775,61 @@ You may export the public key descriptor at anytime but the 12 word recovery phr
                                                             <color key="textColor" red="0.57864717509999997" green="0.57864717509999997" blue="0.57864717509999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <button opaque="NO" tag="17" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZnJ-0B-Mgi">
-                                                            <rect key="frame" x="278" y="4.5" width="28" height="28"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" tag="27" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Testing Node" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lGp-Ln-vMg">
+                                                            <rect key="frame" x="36" y="9.5" width="85" height="16"/>
+                                                            <color key="tintColor" red="0.333293438" green="0.33335629109999998" blue="0.33328947419999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
+                                                            <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="desktopcomputer" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="3Cs-N1-Juh">
+                                                            <rect key="frame" x="8" y="8.5" width="20" height="18"/>
+                                                            <color key="tintColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                             <constraints>
-                                                                <constraint firstAttribute="height" constant="28" id="psR-Zo-8VL"/>
-                                                                <constraint firstAttribute="width" constant="28" id="uBO-Sk-7cQ"/>
+                                                                <constraint firstAttribute="width" constant="20" id="Z2r-lV-W1h"/>
+                                                                <constraint firstAttribute="height" constant="19" id="nEy-Xh-oNg"/>
+                                                            </constraints>
+                                                        </imageView>
+                                                        <button opaque="NO" tag="12" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ow1-MZ-DSx">
+                                                            <rect key="frame" x="279" y="48" width="28" height="28"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="height" constant="28" id="reF-wW-LEa"/>
+                                                                <constraint firstAttribute="width" constant="28" id="zrg-Ma-OHQ"/>
                                                             </constraints>
                                                             <color key="tintColor" red="0.037975538519999998" green="0.3805198669" blue="0.8801537156" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <state key="normal" image="info.circle" catalog="system"/>
                                                         </button>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="💻" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="K7U-9J-bxk">
-                                                            <rect key="frame" x="255" y="10" width="20" height="17"/>
-                                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                            <nil key="textColor"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
-                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="eye" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="czI-ur-V3d">
-                                                            <rect key="frame" x="4" y="10" width="26" height="16.5"/>
-                                                            <color key="tintColor" red="0.56318080459999997" green="0.56318080459999997" blue="0.56318080459999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                        </imageView>
                                                     </subviews>
-                                                    <color key="backgroundColor" red="0.1432691574537093" green="0.17390265680334469" blue="0.19676344636040599" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <color key="backgroundColor" red="0.11157282175978181" green="0.14015675464891095" blue="0.16410052308781731" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
-                                                        <constraint firstItem="n61-Zn-aDm" firstAttribute="top" secondItem="z3r-1y-FSf" secondAttribute="top" constant="4.5" id="0mK-BC-WKc"/>
-                                                        <constraint firstAttribute="height" constant="37" id="8a5-E4-94B"/>
-                                                        <constraint firstItem="czI-ur-V3d" firstAttribute="centerY" secondItem="z3r-1y-FSf" secondAttribute="centerY" id="ByS-MJ-29q"/>
-                                                        <constraint firstItem="ZnJ-0B-Mgi" firstAttribute="centerY" secondItem="z3r-1y-FSf" secondAttribute="centerY" id="KRj-RU-QYs"/>
-                                                        <constraint firstItem="i60-gh-Nax" firstAttribute="leading" secondItem="czI-ur-V3d" secondAttribute="trailing" id="LHC-ex-C59"/>
-                                                        <constraint firstItem="n61-Zn-aDm" firstAttribute="leading" secondItem="czI-ur-V3d" secondAttribute="trailing" constant="1" id="Omd-ex-H2D"/>
-                                                        <constraint firstItem="K7U-9J-bxk" firstAttribute="centerY" secondItem="z3r-1y-FSf" secondAttribute="centerY" id="T3p-BF-f68"/>
-                                                        <constraint firstItem="czI-ur-V3d" firstAttribute="leading" secondItem="z3r-1y-FSf" secondAttribute="leading" constant="4" id="Tze-dB-VIv"/>
-                                                        <constraint firstItem="ZnJ-0B-Mgi" firstAttribute="leading" secondItem="K7U-9J-bxk" secondAttribute="trailing" constant="3" id="eTG-8h-vgf"/>
-                                                        <constraint firstAttribute="trailing" secondItem="ZnJ-0B-Mgi" secondAttribute="trailing" constant="8" id="mzi-V5-fdG"/>
-                                                        <constraint firstItem="i60-gh-Nax" firstAttribute="top" secondItem="n61-Zn-aDm" secondAttribute="bottom" constant="0.5" id="q0w-wV-xO0"/>
+                                                        <constraint firstAttribute="bottom" secondItem="ow1-MZ-DSx" secondAttribute="bottom" constant="8" id="4gl-XU-hH8"/>
+                                                        <constraint firstItem="g8x-Ld-Ezw" firstAttribute="top" secondItem="car-yr-b08" secondAttribute="bottom" constant="2" id="66n-Dg-o7p"/>
+                                                        <constraint firstItem="g8x-Ld-Ezw" firstAttribute="top" secondItem="car-yr-b08" secondAttribute="bottom" constant="2" id="7dm-GM-Ahm"/>
+                                                        <constraint firstItem="i60-gh-Nax" firstAttribute="centerY" secondItem="czI-ur-V3d" secondAttribute="centerY" id="BPt-ru-z3I"/>
+                                                        <constraint firstItem="3Cs-N1-Juh" firstAttribute="leading" secondItem="Mus-be-FaA" secondAttribute="leading" constant="8" id="Cuh-E8-Bnl"/>
+                                                        <constraint firstItem="ev4-Ba-BNf" firstAttribute="leading" secondItem="car-yr-b08" secondAttribute="trailing" constant="6" id="Ejf-nm-mYA"/>
+                                                        <constraint firstItem="LpX-Z8-tmr" firstAttribute="centerY" secondItem="g8x-Ld-Ezw" secondAttribute="centerY" id="G5x-k3-tgS"/>
+                                                        <constraint firstItem="car-yr-b08" firstAttribute="leading" secondItem="g8x-Ld-Ezw" secondAttribute="leading" id="GM9-Xx-V9X"/>
+                                                        <constraint firstItem="lGp-Ln-vMg" firstAttribute="centerY" secondItem="3Cs-N1-Juh" secondAttribute="centerY" id="I5M-pI-jza"/>
+                                                        <constraint firstItem="ev4-Ba-BNf" firstAttribute="centerY" secondItem="car-yr-b08" secondAttribute="centerY" id="KDU-5j-hq8"/>
+                                                        <constraint firstItem="czI-ur-V3d" firstAttribute="top" secondItem="Mus-be-FaA" secondAttribute="top" constant="26" id="QpA-3p-b2W"/>
+                                                        <constraint firstItem="3Cs-N1-Juh" firstAttribute="top" secondItem="Mus-be-FaA" secondAttribute="top" constant="8" id="W6P-vX-xM5"/>
+                                                        <constraint firstItem="car-yr-b08" firstAttribute="leading" secondItem="Mus-be-FaA" secondAttribute="leading" constant="8" id="ZeP-0L-KBn"/>
+                                                        <constraint firstItem="car-yr-b08" firstAttribute="top" secondItem="czI-ur-V3d" secondAttribute="bottom" constant="8.5" id="fpY-aa-H0D"/>
+                                                        <constraint firstAttribute="height" constant="84" id="hHU-PO-3AJ"/>
+                                                        <constraint firstItem="lGp-Ln-vMg" firstAttribute="leading" secondItem="3Cs-N1-Juh" secondAttribute="trailing" constant="8" id="kKt-P8-jjW"/>
+                                                        <constraint firstItem="i60-gh-Nax" firstAttribute="leading" secondItem="czI-ur-V3d" secondAttribute="trailing" constant="8" id="qWE-8u-doz"/>
+                                                        <constraint firstItem="LpX-Z8-tmr" firstAttribute="leading" secondItem="ev4-Ba-BNf" secondAttribute="leading" id="uHL-Ae-M4f"/>
+                                                        <constraint firstItem="g8x-Ld-Ezw" firstAttribute="leading" secondItem="Mus-be-FaA" secondAttribute="leading" constant="8" id="vrr-wp-ppK"/>
+                                                        <constraint firstAttribute="trailing" secondItem="ow1-MZ-DSx" secondAttribute="trailing" constant="8" id="wdt-AB-c7Z"/>
+                                                        <constraint firstItem="czI-ur-V3d" firstAttribute="leading" secondItem="Mus-be-FaA" secondAttribute="leading" constant="8" id="xRD-2d-Vda"/>
                                                     </constraints>
                                                 </view>
-                                                <button opaque="NO" tag="12" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ciE-Bi-Iml">
-                                                    <rect key="frame" x="240.5" y="114" width="20" height="22"/>
-                                                    <color key="tintColor" red="0.037975538519999998" green="0.3805198669" blue="0.8801537156" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                    <state key="normal" image="pencil.circle" catalog="system"/>
-                                                </button>
-                                                <label opaque="NO" userInteractionEnabled="NO" tag="14" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2020-Feb-09 15:48" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TQL-WW-Jpr">
-                                                    <rect key="frame" x="56" y="103" width="87.5" height="11"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="9"/>
-                                                    <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <button opaque="NO" tag="10" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="g94-fh-bhc">
-                                                    <rect key="frame" x="15" y="114" width="22" height="22"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="22" id="Yxe-rR-rcK"/>
-                                                        <constraint firstAttribute="width" constant="22" id="q1D-d3-nVC"/>
-                                                    </constraints>
-                                                    <color key="tintColor" red="0.037975538519999998" green="0.3805198669" blue="0.8801537156" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                    <state key="normal" image="info.circle" catalog="system"/>
-                                                </button>
-                                                <switch opaque="NO" tag="2" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="SPc-CN-QXX">
-                                                    <rect key="frame" x="15" y="21" width="51" height="31"/>
-                                                </switch>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Created:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DLd-eo-yhH">
-                                                    <rect key="frame" x="16" y="103" width="38" height="11"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="9"/>
-                                                    <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" tag="24" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Active" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tdt-Ap-iVt">
-                                                    <rect key="frame" x="72" y="26.5" width="47.5" height="20.5"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" tag="13" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2020-Feb-09 15:48" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kYv-xd-YpP">
-                                                    <rect key="frame" x="241.5" y="103" width="87.5" height="11"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="9"/>
-                                                    <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Updated:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gEN-a7-pZj">
-                                                    <rect key="frame" x="196.5" y="103" width="40.5" height="11"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="9"/>
-                                                    <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
                                                 <view clipsSubviews="YES" tag="25" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="egC-uO-FYs">
-                                                    <rect key="frame" x="16" y="312" width="313" height="38"/>
+                                                    <rect key="frame" x="16" y="317" width="313" height="38"/>
                                                     <subviews>
-                                                        <stackView opaque="NO" tag="25" contentMode="scaleToFill" distribution="equalSpacing" spacing="-8" translatesAutoresizingMaskIntoConstraints="NO" id="KoW-G0-uW0">
-                                                            <rect key="frame" x="8" y="6" width="298" height="26"/>
+                                                        <stackView opaque="NO" tag="25" contentMode="scaleToFill" distribution="equalSpacing" spacing="34" translatesAutoresizingMaskIntoConstraints="NO" id="KoW-G0-uW0">
+                                                            <rect key="frame" x="8" y="6" width="297" height="26"/>
                                                             <subviews>
                                                                 <button opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Dy0-g8-zgF">
                                                                     <rect key="frame" x="0.0" y="0.0" width="26" height="26"/>
@@ -3811,22 +3837,22 @@ You may export the public key descriptor at anytime but the 12 word recovery phr
                                                                     <state key="normal" image="eye" catalog="system"/>
                                                                 </button>
                                                                 <button opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3ix-Mm-4fG">
-                                                                    <rect key="frame" x="60.5" y="0.0" width="22.5" height="26"/>
+                                                                    <rect key="frame" x="60" y="0.0" width="22.5" height="26"/>
                                                                     <color key="tintColor" red="0.037975538519999998" green="0.3805198669" blue="0.8801537156" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <state key="normal" image="checkmark.seal" catalog="system"/>
                                                                 </button>
                                                                 <button opaque="NO" tag="5" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4pY-rI-DWW">
-                                                                    <rect key="frame" x="117.5" y="0.0" width="18" height="26"/>
+                                                                    <rect key="frame" x="117" y="0.0" width="18" height="26"/>
                                                                     <color key="tintColor" red="0.037975538519999998" green="0.3805198669" blue="0.8801537156" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <state key="normal" image="arrow.clockwise" catalog="system"/>
                                                                 </button>
                                                                 <button opaque="NO" tag="6" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="AT4-Oq-skO">
-                                                                    <rect key="frame" x="169.5" y="0.0" width="19.5" height="26"/>
+                                                                    <rect key="frame" x="169" y="0.0" width="19.5" height="26"/>
                                                                     <color key="tintColor" red="0.037975538519999998" green="0.3805198669" blue="0.8801537156" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <state key="normal" image="qrcode" catalog="system"/>
                                                                 </button>
                                                                 <button opaque="NO" clipsSubviews="YES" tag="9" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X5s-y7-UKM">
-                                                                    <rect key="frame" x="223.5" y="0.0" width="21" height="26"/>
+                                                                    <rect key="frame" x="223" y="0.0" width="21" height="26"/>
                                                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                     <color key="tintColor" systemColor="systemBlueColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <state key="normal" image="list.number" catalog="system">
@@ -3834,7 +3860,7 @@ You may export the public key descriptor at anytime but the 12 word recovery phr
                                                                     </state>
                                                                 </button>
                                                                 <button opaque="NO" tag="7" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rep-fm-fmf">
-                                                                    <rect key="frame" x="279" y="0.0" width="19" height="26"/>
+                                                                    <rect key="frame" x="278" y="0.0" width="19" height="26"/>
                                                                     <color key="tintColor" red="0.037975538519999998" green="0.3805198669" blue="0.8801537156" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <state key="normal" image="thermometer.snowflake" catalog="system"/>
                                                                 </button>
@@ -3847,82 +3873,181 @@ You may export the public key descriptor at anytime but the 12 word recovery phr
                                                     </subviews>
                                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
-                                                        <constraint firstItem="KoW-G0-uW0" firstAttribute="top" secondItem="egC-uO-FYs" secondAttribute="top" constant="6" id="0Nb-0C-AED"/>
-                                                        <constraint firstAttribute="height" constant="38" id="J6H-WT-W0x"/>
-                                                        <constraint firstAttribute="trailing" secondItem="KoW-G0-uW0" secondAttribute="trailing" constant="7" id="LeS-0O-Yng"/>
-                                                        <constraint firstAttribute="bottom" secondItem="KoW-G0-uW0" secondAttribute="bottom" constant="6" id="Qg8-4u-FH9"/>
-                                                        <constraint firstItem="KoW-G0-uW0" firstAttribute="leading" secondItem="egC-uO-FYs" secondAttribute="leading" constant="8" id="rph-cY-MpC"/>
+                                                        <constraint firstAttribute="trailing" secondItem="KoW-G0-uW0" secondAttribute="trailing" constant="8" id="0DO-7K-JfV"/>
+                                                        <constraint firstItem="KoW-G0-uW0" firstAttribute="leading" secondItem="egC-uO-FYs" secondAttribute="leading" constant="8" id="Ip5-z2-zHg"/>
+                                                        <constraint firstAttribute="bottom" secondItem="KoW-G0-uW0" secondAttribute="bottom" constant="6" id="ZCx-o6-EJ9"/>
+                                                        <constraint firstItem="KoW-G0-uW0" firstAttribute="top" secondItem="egC-uO-FYs" secondAttribute="top" constant="6" id="cWH-Ad-0JC"/>
                                                     </constraints>
                                                 </view>
-                                                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" tag="8" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Testnet" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dOn-Dy-2vG">
-                                                    <rect key="frame" x="255" y="23.5" width="75" height="26"/>
-                                                    <color key="backgroundColor" red="0.1432691574537093" green="0.17390265680334469" blue="0.19676344636040599" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Node:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4rs-FI-UmB">
+                                                    <rect key="frame" x="15" y="211" width="30.5" height="12"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="10"/>
+                                                    <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <constraints>
+                                                <constraint firstItem="AMk-q2-GQu" firstAttribute="leading" secondItem="nN1-0D-mSU" secondAttribute="leadingMargin" id="1e0-fP-GAl"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="egC-uO-FYs" secondAttribute="trailing" constant="1" id="2SP-oR-rya"/>
+                                                <constraint firstItem="AMk-q2-GQu" firstAttribute="top" secondItem="vxO-CT-ic3" secondAttribute="bottom" constant="4" id="42s-Y1-b49"/>
+                                                <constraint firstItem="vxO-CT-ic3" firstAttribute="leading" secondItem="nN1-0D-mSU" secondAttribute="leadingMargin" id="48v-qs-W3f"/>
+                                                <constraint firstItem="AMk-q2-GQu" firstAttribute="trailing" secondItem="nN1-0D-mSU" secondAttribute="trailingMargin" id="4bt-rX-sm7"/>
+                                                <constraint firstItem="TQL-WW-Jpr" firstAttribute="leading" secondItem="DLd-eo-yhH" secondAttribute="trailing" constant="8" id="792-19-H3I"/>
+                                                <constraint firstAttribute="bottom" secondItem="egC-uO-FYs" secondAttribute="bottom" constant="8" id="7E3-xI-vHf"/>
+                                                <constraint firstItem="egC-uO-FYs" firstAttribute="leading" secondItem="nN1-0D-mSU" secondAttribute="leading" constant="16" id="9tI-4L-g63"/>
+                                                <constraint firstItem="DLd-eo-yhH" firstAttribute="leading" secondItem="nN1-0D-mSU" secondAttribute="leadingMargin" constant="-1" id="Aib-Z8-KYd"/>
+                                                <constraint firstItem="egC-uO-FYs" firstAttribute="top" secondItem="Mus-be-FaA" secondAttribute="bottom" constant="6" id="Dc1-eQ-iHs"/>
+                                                <constraint firstItem="SPc-CN-QXX" firstAttribute="leading" secondItem="nN1-0D-mSU" secondAttribute="leadingMargin" id="Fpe-wA-pGa"/>
+                                                <constraint firstItem="kYv-xd-YpP" firstAttribute="leading" secondItem="gEN-a7-pZj" secondAttribute="trailing" constant="8.5" id="GMc-oN-EuI"/>
+                                                <constraint firstItem="gEN-a7-pZj" firstAttribute="centerY" secondItem="DLd-eo-yhH" secondAttribute="centerY" id="GOp-sy-Myb"/>
+                                                <constraint firstItem="Mus-be-FaA" firstAttribute="trailing" secondItem="AMk-q2-GQu" secondAttribute="trailing" id="Kzr-MK-vL7"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="kYv-xd-YpP" secondAttribute="trailing" constant="2.5" id="MNz-r5-Ims"/>
+                                                <constraint firstItem="DLd-eo-yhH" firstAttribute="top" secondItem="6Sm-zd-H8y" secondAttribute="bottom" id="SPw-9m-OWU"/>
+                                                <constraint firstItem="TQL-WW-Jpr" firstAttribute="centerY" secondItem="DLd-eo-yhH" secondAttribute="centerY" id="T9Q-PP-gPW"/>
+                                                <constraint firstAttribute="trailing" secondItem="7yp-J1-Thl" secondAttribute="trailing" id="TaX-4v-sep"/>
+                                                <constraint firstItem="6Sm-zd-H8y" firstAttribute="trailing" secondItem="nN1-0D-mSU" secondAttribute="trailingMargin" id="YMO-cS-Wbg"/>
+                                                <constraint firstItem="vxO-CT-ic3" firstAttribute="top" secondItem="DLd-eo-yhH" secondAttribute="bottom" constant="2" id="YjN-qv-xX9"/>
+                                                <constraint firstItem="egC-uO-FYs" firstAttribute="leading" secondItem="nN1-0D-mSU" secondAttribute="leadingMargin" constant="1" id="ZG9-Ce-jf3"/>
+                                                <constraint firstAttribute="trailing" secondItem="egC-uO-FYs" secondAttribute="trailing" constant="16" id="aVG-FX-eUq"/>
+                                                <constraint firstItem="4rs-FI-UmB" firstAttribute="leading" secondItem="nN1-0D-mSU" secondAttribute="leadingMargin" id="aq3-Ch-tiE"/>
+                                                <constraint firstItem="7yp-J1-Thl" firstAttribute="top" secondItem="nN1-0D-mSU" secondAttribute="top" id="dNb-Es-J4R"/>
+                                                <constraint firstItem="tdt-Ap-iVt" firstAttribute="leading" secondItem="SPc-CN-QXX" secondAttribute="trailing" constant="8" id="etg-uT-yW5"/>
+                                                <constraint firstItem="Mus-be-FaA" firstAttribute="top" secondItem="4rs-FI-UmB" secondAttribute="bottom" constant="4" id="lWq-q2-bGY"/>
+                                                <constraint firstItem="7yp-J1-Thl" firstAttribute="leading" secondItem="nN1-0D-mSU" secondAttribute="leading" id="p5i-3d-X6S"/>
+                                                <constraint firstItem="tdt-Ap-iVt" firstAttribute="centerY" secondItem="SPc-CN-QXX" secondAttribute="centerY" id="qoe-Rp-MAB"/>
+                                                <constraint firstItem="dOn-Dy-2vG" firstAttribute="trailing" secondItem="nN1-0D-mSU" secondAttribute="trailingMargin" id="sYQ-TV-btY"/>
+                                                <constraint firstItem="4rs-FI-UmB" firstAttribute="top" secondItem="AMk-q2-GQu" secondAttribute="bottom" constant="9" id="sx8-tZ-5PM"/>
+                                                <constraint firstItem="6Sm-zd-H8y" firstAttribute="leading" secondItem="nN1-0D-mSU" secondAttribute="leadingMargin" id="tQi-In-qJo"/>
+                                                <constraint firstItem="SPc-CN-QXX" firstAttribute="top" secondItem="7yp-J1-Thl" secondAttribute="bottom" constant="8" id="uYc-vC-NHp"/>
+                                                <constraint firstItem="kYv-xd-YpP" firstAttribute="centerY" secondItem="DLd-eo-yhH" secondAttribute="centerY" id="veY-Dz-76a"/>
+                                                <constraint firstItem="Mus-be-FaA" firstAttribute="leading" secondItem="AMk-q2-GQu" secondAttribute="leading" id="wVt-ch-vnl"/>
+                                                <constraint firstItem="dOn-Dy-2vG" firstAttribute="centerY" secondItem="SPc-CN-QXX" secondAttribute="centerY" id="xRe-L1-hd2"/>
+                                                <constraint firstItem="6Sm-zd-H8y" firstAttribute="top" secondItem="SPc-CN-QXX" secondAttribute="bottom" constant="5" id="xoV-hV-vzY"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                        <color key="backgroundColor" red="0.085763759910000001" green="0.10179834810000001" blue="0.1143214479" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="multiSigWalletCell" rowHeight="435" id="Pu7-d1-gy4">
+                                        <rect key="frame" x="15" y="712.5" width="345" height="435"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Pu7-d1-gy4" id="EKP-cw-XcR">
+                                            <rect key="frame" x="0.0" y="0.0" width="345" height="435"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" tag="1" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0.00000000" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KGY-cW-hyS">
+                                                    <rect key="frame" x="15" y="94" width="315" height="48"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="height" constant="26" id="cfH-MH-xOT"/>
-                                                        <constraint firstAttribute="width" constant="75" id="qfy-GY-E2l"/>
+                                                        <constraint firstAttribute="height" constant="48" id="buo-Am-Tzk"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="46"/>
+                                                    <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" tag="14" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2020-Feb-09 15:48" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="75R-94-8gm">
+                                                    <rect key="frame" x="56" y="142" width="87.5" height="11"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="9"/>
+                                                    <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <switch opaque="NO" tag="2" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1u0-OO-HE9">
+                                                    <rect key="frame" x="15" y="60" width="51" height="31"/>
+                                                </switch>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Created:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ckd-q3-zNx">
+                                                    <rect key="frame" x="16" y="142" width="38" height="11"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="9"/>
+                                                    <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" tag="24" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Active" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oW9-IX-PDE">
+                                                    <rect key="frame" x="72" y="65.5" width="47.5" height="20.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" tag="13" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2020-Feb-09 15:48" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xiT-PY-mWf">
+                                                    <rect key="frame" x="241.5" y="142" width="87.5" height="11"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="9"/>
+                                                    <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Updated:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MfD-7G-p6e">
+                                                    <rect key="frame" x="196.5" y="142" width="40.5" height="11"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="9"/>
+                                                    <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" tag="8" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Testnet" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B1v-ZE-lI2">
+                                                    <rect key="frame" x="254" y="62.5" width="75" height="26"/>
+                                                    <color key="backgroundColor" red="0.098183676662712258" green="0.1306873117954245" blue="0.15651240682741119" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="75" id="85i-cA-AvM"/>
+                                                        <constraint firstAttribute="height" constant="26" id="Xbq-y2-0Xo"/>
                                                     </constraints>
                                                     <fontDescription key="fontDescription" type="system" weight="heavy" pointSize="12"/>
                                                     <color key="textColor" systemColor="systemOrangeColor" red="1" green="0.58431372550000005" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                            </subviews>
-                                            <constraints>
-                                                <constraint firstItem="Mus-be-FaA" firstAttribute="top" secondItem="z3r-1y-FSf" secondAttribute="bottom" constant="8" id="0nP-hN-ndm"/>
-                                                <constraint firstAttribute="trailing" secondItem="6Sm-zd-H8y" secondAttribute="trailing" constant="15" id="13S-tZ-asV"/>
-                                                <constraint firstItem="kYv-xd-YpP" firstAttribute="leading" secondItem="gEN-a7-pZj" secondAttribute="trailing" constant="4.5" id="1Kj-h4-ZVW"/>
-                                                <constraint firstAttribute="trailing" secondItem="egC-uO-FYs" secondAttribute="trailing" constant="16" id="1ZP-6j-QiF"/>
-                                                <constraint firstItem="egC-uO-FYs" firstAttribute="bottom" secondItem="nN1-0D-mSU" secondAttribute="bottomMargin" constant="-9" id="1cd-mf-361"/>
-                                                <constraint firstItem="SPc-CN-QXX" firstAttribute="leading" secondItem="nN1-0D-mSU" secondAttribute="leadingMargin" id="1mM-wm-yVT"/>
-                                                <constraint firstItem="AMk-q2-GQu" firstAttribute="leading" secondItem="nN1-0D-mSU" secondAttribute="leadingMargin" constant="1" id="3Hw-0v-FEu"/>
-                                                <constraint firstItem="Mus-be-FaA" firstAttribute="trailing" secondItem="nN1-0D-mSU" secondAttribute="trailingMargin" id="5PH-oq-uMQ"/>
-                                                <constraint firstItem="6Sm-zd-H8y" firstAttribute="top" secondItem="SPc-CN-QXX" secondAttribute="bottom" constant="3" id="5Wj-mp-wtl"/>
-                                                <constraint firstItem="DLd-eo-yhH" firstAttribute="leading" secondItem="nN1-0D-mSU" secondAttribute="leading" constant="16" id="6TX-A1-MRs"/>
-                                                <constraint firstItem="ciE-Bi-Iml" firstAttribute="centerY" secondItem="7jg-Bo-IWL" secondAttribute="centerY" id="8np-oL-70V"/>
-                                                <constraint firstItem="yya-jz-VRS" firstAttribute="leading" secondItem="ciE-Bi-Iml" secondAttribute="trailing" constant="12" id="9Xj-Vi-t3Z"/>
-                                                <constraint firstItem="yya-jz-VRS" firstAttribute="centerY" secondItem="7jg-Bo-IWL" secondAttribute="centerY" id="9aj-IC-tnA"/>
-                                                <constraint firstItem="dOn-Dy-2vG" firstAttribute="centerY" secondItem="tdt-Ap-iVt" secondAttribute="centerY" id="AsI-wJ-Bow"/>
-                                                <constraint firstItem="z3r-1y-FSf" firstAttribute="trailing" secondItem="nN1-0D-mSU" secondAttribute="trailingMargin" id="CxL-aE-FWj"/>
-                                                <constraint firstItem="z3r-1y-FSf" firstAttribute="leading" secondItem="AMk-q2-GQu" secondAttribute="leading" id="DFC-Pz-hbh"/>
-                                                <constraint firstItem="vxO-CT-ic3" firstAttribute="leading" secondItem="nN1-0D-mSU" secondAttribute="leadingMargin" constant="1" id="HgG-13-UBw"/>
-                                                <constraint firstItem="egC-uO-FYs" firstAttribute="leading" secondItem="nN1-0D-mSU" secondAttribute="leading" constant="16" id="JFV-uF-aR7"/>
-                                                <constraint firstAttribute="trailingMargin" secondItem="yya-jz-VRS" secondAttribute="trailing" constant="1" id="Oyu-ji-bqH"/>
-                                                <constraint firstItem="egC-uO-FYs" firstAttribute="top" secondItem="Mus-be-FaA" secondAttribute="bottom" constant="8" id="PdR-WQ-EAN"/>
-                                                <constraint firstItem="g94-fh-bhc" firstAttribute="leading" secondItem="nN1-0D-mSU" secondAttribute="leadingMargin" id="QJr-rq-FS7"/>
-                                                <constraint firstItem="tdt-Ap-iVt" firstAttribute="leading" secondItem="SPc-CN-QXX" secondAttribute="trailing" constant="8" id="UOo-uw-abJ"/>
-                                                <constraint firstItem="dOn-Dy-2vG" firstAttribute="trailing" secondItem="nN1-0D-mSU" secondAttribute="trailingMargin" id="W1h-F6-ygo"/>
-                                                <constraint firstItem="tdt-Ap-iVt" firstAttribute="centerY" secondItem="SPc-CN-QXX" secondAttribute="centerY" id="XSd-SF-Ixf"/>
-                                                <constraint firstItem="g94-fh-bhc" firstAttribute="top" secondItem="DLd-eo-yhH" secondAttribute="bottom" id="Zv0-nc-bB1"/>
-                                                <constraint firstItem="Mus-be-FaA" firstAttribute="leading" secondItem="nN1-0D-mSU" secondAttribute="leadingMargin" id="aUn-Af-AIk"/>
-                                                <constraint firstItem="TQL-WW-Jpr" firstAttribute="centerY" secondItem="DLd-eo-yhH" secondAttribute="centerY" id="aVI-Hb-I1N"/>
-                                                <constraint firstItem="AMk-q2-GQu" firstAttribute="trailing" secondItem="nN1-0D-mSU" secondAttribute="trailingMargin" id="aWS-wC-Qo7"/>
-                                                <constraint firstItem="z3r-1y-FSf" firstAttribute="top" secondItem="AMk-q2-GQu" secondAttribute="bottom" constant="8" id="ehq-T5-EIu"/>
-                                                <constraint firstItem="TQL-WW-Jpr" firstAttribute="leading" secondItem="DLd-eo-yhH" secondAttribute="trailing" constant="2" id="fic-VC-SDk"/>
-                                                <constraint firstAttribute="trailing" secondItem="kYv-xd-YpP" secondAttribute="trailing" constant="16" id="gDf-bP-71K"/>
-                                                <constraint firstItem="kYv-xd-YpP" firstAttribute="centerY" secondItem="gEN-a7-pZj" secondAttribute="centerY" id="gxQ-fb-C27"/>
-                                                <constraint firstItem="gEN-a7-pZj" firstAttribute="centerY" secondItem="TQL-WW-Jpr" secondAttribute="centerY" id="i3W-6J-Qoa"/>
-                                                <constraint firstItem="6Sm-zd-H8y" firstAttribute="leading" secondItem="nN1-0D-mSU" secondAttribute="leadingMargin" id="jR4-ZY-pIp"/>
-                                                <constraint firstItem="Mus-be-FaA" firstAttribute="trailing" secondItem="nN1-0D-mSU" secondAttribute="trailingMargin" id="nDu-Qs-dab"/>
-                                                <constraint firstItem="AMk-q2-GQu" firstAttribute="top" secondItem="vxO-CT-ic3" secondAttribute="bottom" constant="7" id="oja-GW-uBG"/>
-                                                <constraint firstItem="vxO-CT-ic3" firstAttribute="top" secondItem="g94-fh-bhc" secondAttribute="bottom" constant="4" id="pS8-hE-b7I"/>
-                                                <constraint firstItem="kYv-xd-YpP" firstAttribute="centerY" secondItem="TQL-WW-Jpr" secondAttribute="centerY" id="pTJ-oz-u0t"/>
-                                                <constraint firstItem="Mus-be-FaA" firstAttribute="leading" secondItem="nN1-0D-mSU" secondAttribute="leadingMargin" id="qQZ-cf-olx"/>
-                                                <constraint firstItem="7jg-Bo-IWL" firstAttribute="centerY" secondItem="g94-fh-bhc" secondAttribute="centerY" id="s0q-h1-mXs"/>
-                                                <constraint firstItem="SPc-CN-QXX" firstAttribute="top" secondItem="nN1-0D-mSU" secondAttribute="topMargin" constant="10" id="xY3-GM-tl7"/>
-                                                <constraint firstItem="DLd-eo-yhH" firstAttribute="top" secondItem="6Sm-zd-H8y" secondAttribute="bottom" id="yyI-K4-9OF"/>
-                                                <constraint firstItem="7jg-Bo-IWL" firstAttribute="leading" secondItem="g94-fh-bhc" secondAttribute="trailing" constant="7" id="zhf-81-zCK"/>
-                                            </constraints>
-                                        </tableViewCellContentView>
-                                        <color key="backgroundColor" red="0.1051254794" green="0.12928032880000001" blue="0.14184883240000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                    </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="multiSigWalletCell" rowHeight="398" id="Pu7-d1-gy4">
-                                        <rect key="frame" x="0.0" y="735.5" width="345" height="398"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Pu7-d1-gy4" id="EKP-cw-XcR">
-                                            <rect key="frame" x="0.0" y="0.0" width="345" height="398"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
+                                                <view tag="33" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kho-sl-W6K">
+                                                    <rect key="frame" x="0.0" y="0.0" width="345" height="44"/>
+                                                    <subviews>
+                                                        <stackView opaque="NO" contentMode="scaleToFill" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="oWp-iO-M9B">
+                                                            <rect key="frame" x="142" y="11" width="61.5" height="22"/>
+                                                            <subviews>
+                                                                <button opaque="NO" tag="10" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PjG-od-EAV">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="20" height="22"/>
+                                                                    <color key="tintColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                    <state key="normal" image="info.circle" catalog="system"/>
+                                                                </button>
+                                                                <label opaque="NO" userInteractionEnabled="NO" tag="11" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="BIP84" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vbq-pg-bVi">
+                                                                    <rect key="frame" x="27" y="0.0" width="34.5" height="22"/>
+                                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                                    <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                    <nil key="highlightedColor"/>
+                                                                </label>
+                                                            </subviews>
+                                                        </stackView>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2 of 3 multisig" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fPC-rc-FTn">
+                                                            <rect key="frame" x="256" y="15" width="81" height="14.5"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                            <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <button opaque="NO" tag="12" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vmf-kd-EW6">
+                                                            <rect key="frame" x="228" y="11" width="20" height="22"/>
+                                                            <color key="tintColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                            <state key="normal" image="pencil.circle" catalog="system"/>
+                                                        </button>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Warm Wallet" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qz7-5r-uqu">
+                                                            <rect key="frame" x="36" y="15" width="71.5" height="14.5"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                            <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hWz-o6-VXk">
+                                                            <rect key="frame" x="8" y="11" width="20" height="22"/>
+                                                            <color key="tintColor" systemColor="systemYellowColor" red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            <state key="normal" image="sun.min" catalog="system"/>
+                                                        </button>
+                                                    </subviews>
+                                                    <color key="backgroundColor" red="0.0" green="0.16319443580000001" blue="0.33833677029999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <constraints>
+                                                        <constraint firstItem="vmf-kd-EW6" firstAttribute="centerY" secondItem="kho-sl-W6K" secondAttribute="centerY" id="6SK-PP-21U"/>
+                                                        <constraint firstAttribute="trailingMargin" secondItem="fPC-rc-FTn" secondAttribute="trailing" id="Cv3-jE-V3F"/>
+                                                        <constraint firstItem="hWz-o6-VXk" firstAttribute="leading" secondItem="kho-sl-W6K" secondAttribute="leading" constant="8" id="H85-kF-A01"/>
+                                                        <constraint firstItem="fPC-rc-FTn" firstAttribute="leading" secondItem="vmf-kd-EW6" secondAttribute="trailing" constant="8" id="RjQ-dh-9oa"/>
+                                                        <constraint firstItem="qz7-5r-uqu" firstAttribute="leading" secondItem="hWz-o6-VXk" secondAttribute="trailing" constant="8" id="RnS-a2-Srz"/>
+                                                        <constraint firstItem="oWp-iO-M9B" firstAttribute="centerX" secondItem="kho-sl-W6K" secondAttribute="centerX" id="Y6c-e3-6po"/>
+                                                        <constraint firstItem="qz7-5r-uqu" firstAttribute="centerY" secondItem="kho-sl-W6K" secondAttribute="centerY" id="aNG-vi-OIc"/>
+                                                        <constraint firstItem="hWz-o6-VXk" firstAttribute="centerY" secondItem="kho-sl-W6K" secondAttribute="centerY" id="lgb-XX-VZH"/>
+                                                        <constraint firstAttribute="height" constant="44" id="nA9-h8-c3k"/>
+                                                        <constraint firstItem="fPC-rc-FTn" firstAttribute="centerY" secondItem="kho-sl-W6K" secondAttribute="centerY" id="oQk-He-80s"/>
+                                                        <constraint firstItem="oWp-iO-M9B" firstAttribute="centerY" secondItem="kho-sl-W6K" secondAttribute="centerY" id="pZu-O8-DI0"/>
+                                                        <constraint firstItem="qz7-5r-uqu" firstAttribute="leading" secondItem="hWz-o6-VXk" secondAttribute="trailing" constant="8" id="ukS-oS-hdo"/>
+                                                    </constraints>
+                                                </view>
                                                 <view clipsSubviews="YES" tag="26" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Pie-V8-QKM">
-                                                    <rect key="frame" x="15" y="289" width="315" height="55"/>
+                                                    <rect key="frame" x="15" y="310" width="315" height="55"/>
                                                     <subviews>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="desktopcomputer" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="cmh-IY-0zE">
                                                             <rect key="frame" x="3" y="2.5" width="29" height="18"/>
@@ -3984,7 +4109,7 @@ You may export the public key descriptor at anytime but the 12 word recovery phr
                                                             <state key="normal" image="info.circle" catalog="system"/>
                                                         </button>
                                                     </subviews>
-                                                    <color key="backgroundColor" red="0.14014528487774194" green="0.17214550810387905" blue="0.19040927021725895" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <color key="backgroundColor" red="0.098183676662712258" green="0.1306873117954245" blue="0.15651240682741119" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
                                                         <constraint firstItem="f2l-aT-168" firstAttribute="top" secondItem="Pie-V8-QKM" secondAttribute="top" constant="5" id="4YY-X5-DNb"/>
                                                         <constraint firstItem="cmh-IY-0zE" firstAttribute="top" secondItem="Pie-V8-QKM" secondAttribute="top" constant="2" id="C5v-wq-Q7C"/>
@@ -4006,35 +4131,14 @@ You may export the public key descriptor at anytime but the 12 word recovery phr
                                                         <constraint firstItem="RYz-Mu-lfI" firstAttribute="leading" secondItem="cmh-IY-0zE" secondAttribute="trailing" id="xdQ-m4-HBY"/>
                                                     </constraints>
                                                 </view>
-                                                <label opaque="NO" userInteractionEnabled="NO" tag="11" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="BIP84" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vbq-pg-bVi">
-                                                    <rect key="frame" x="44" y="118" width="34.5" height="14.5"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                                    <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2 of 3 multisig" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fPC-rc-FTn">
-                                                    <rect key="frame" x="248" y="118" width="81" height="14.5"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                                    <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Signers:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iY3-wV-4kw">
-                                                    <rect key="frame" x="16" y="140" width="43" height="12"/>
+                                                    <rect key="frame" x="16" y="161" width="43" height="12"/>
                                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="10"/>
                                                     <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" tag="1" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0.00000000" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KGY-cW-hyS">
-                                                    <rect key="frame" x="15" y="55" width="315" height="48"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="48" id="buo-Am-Tzk"/>
-                                                    </constraints>
-                                                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="46"/>
-                                                    <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
                                                 <view clipsSubviews="YES" tag="21" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xIK-fc-Mq4">
-                                                    <rect key="frame" x="16" y="154" width="314" height="37"/>
+                                                    <rect key="frame" x="16" y="175" width="314" height="37"/>
                                                     <subviews>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="key.png" translatesAutoresizingMaskIntoConstraints="NO" id="Z6v-s2-xfj">
                                                             <rect key="frame" x="4" y="4" width="20" height="15"/>
@@ -4090,7 +4194,7 @@ You may export the public key descriptor at anytime but the 12 word recovery phr
                                                             <state key="normal" image="info.circle" catalog="system"/>
                                                         </button>
                                                     </subviews>
-                                                    <color key="backgroundColor" red="0.14014528487774194" green="0.17214550810387905" blue="0.19040927021725895" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <color key="backgroundColor" red="0.098183676662712258" green="0.1306873117954245" blue="0.15651240682741119" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
                                                         <constraint firstItem="Wqe-tS-Vvx" firstAttribute="leading" secondItem="xIK-fc-Mq4" secondAttribute="leading" constant="4" id="1E5-rk-1EV"/>
                                                         <constraint firstItem="VFK-kv-E0g" firstAttribute="centerY" secondItem="xIK-fc-Mq4" secondAttribute="centerY" id="4hp-2j-JG2"/>
@@ -4108,7 +4212,7 @@ You may export the public key descriptor at anytime but the 12 word recovery phr
                                                     </constraints>
                                                 </view>
                                                 <view clipsSubviews="YES" tag="22" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZsE-bQ-qYq">
-                                                    <rect key="frame" x="16" y="199" width="314" height="37"/>
+                                                    <rect key="frame" x="16" y="220" width="314" height="37"/>
                                                     <subviews>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="key.png" translatesAutoresizingMaskIntoConstraints="NO" id="MUJ-wN-rUy">
                                                             <rect key="frame" x="4" y="4" width="20" height="15"/>
@@ -4160,7 +4264,7 @@ You may export the public key descriptor at anytime but the 12 word recovery phr
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                     </subviews>
-                                                    <color key="backgroundColor" red="0.14014528487774194" green="0.17214550810387905" blue="0.19040927021725895" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <color key="backgroundColor" red="0.098183676662712258" green="0.1306873117954245" blue="0.15651240682741119" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
                                                         <constraint firstItem="0tT-hv-us0" firstAttribute="leading" secondItem="tcQ-uu-jmf" secondAttribute="trailing" constant="3" id="1uf-S3-M6G"/>
                                                         <constraint firstItem="0tT-hv-us0" firstAttribute="centerY" secondItem="ZsE-bQ-qYq" secondAttribute="centerY" id="2Iy-4u-tWx"/>
@@ -4178,7 +4282,7 @@ You may export the public key descriptor at anytime but the 12 word recovery phr
                                                     </constraints>
                                                 </view>
                                                 <view clipsSubviews="YES" tag="23" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pII-Us-N4E">
-                                                    <rect key="frame" x="16" y="244" width="314" height="37"/>
+                                                    <rect key="frame" x="16" y="265" width="314" height="37"/>
                                                     <subviews>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" tag="21" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="key.png" translatesAutoresizingMaskIntoConstraints="NO" id="VUM-3h-j6T">
                                                             <rect key="frame" x="4" y="4" width="20" height="15"/>
@@ -4230,7 +4334,7 @@ You may export the public key descriptor at anytime but the 12 word recovery phr
                                                             <state key="normal" image="info.circle" catalog="system"/>
                                                         </button>
                                                     </subviews>
-                                                    <color key="backgroundColor" red="0.14014528487774194" green="0.17214550810387905" blue="0.19040927021725895" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <color key="backgroundColor" red="0.098183676662712258" green="0.1306873117954245" blue="0.15651240682741119" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
                                                         <constraint firstItem="km0-m6-cl4" firstAttribute="leading" secondItem="HnI-vK-gV2" secondAttribute="trailing" id="12g-iG-FCF"/>
                                                         <constraint firstItem="Upj-Sb-mG8" firstAttribute="leading" secondItem="VUM-3h-j6T" secondAttribute="trailing" constant="5" id="Df1-Da-WDu"/>
@@ -4247,28 +4351,8 @@ You may export the public key descriptor at anytime but the 12 word recovery phr
                                                         <constraint firstAttribute="height" constant="37" id="xmI-b1-GP7"/>
                                                     </constraints>
                                                 </view>
-                                                <button opaque="NO" tag="12" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vmf-kd-EW6">
-                                                    <rect key="frame" x="216" y="114" width="20" height="22"/>
-                                                    <color key="tintColor" red="0.037975538519999998" green="0.3805198669" blue="0.8801537156" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                    <state key="normal" image="pencil.circle" catalog="system"/>
-                                                </button>
-                                                <label opaque="NO" userInteractionEnabled="NO" tag="14" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2020-Feb-09 15:48" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="75R-94-8gm">
-                                                    <rect key="frame" x="56" y="103" width="87.5" height="11"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="9"/>
-                                                    <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <button opaque="NO" tag="10" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PjG-od-EAV">
-                                                    <rect key="frame" x="15" y="114" width="22" height="22"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="width" constant="22" id="NPw-Tm-Xhb"/>
-                                                        <constraint firstAttribute="height" constant="22" id="kt0-bL-KVV"/>
-                                                    </constraints>
-                                                    <color key="tintColor" red="0.037975538519999998" green="0.3805198669" blue="0.8801537156" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                    <state key="normal" image="info.circle" catalog="system"/>
-                                                </button>
-                                                <view clipsSubviews="YES" tag="25" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1Wn-ab-2Sg">
-                                                    <rect key="frame" x="16" y="349" width="313" height="38"/>
+                                                <view clipsSubviews="YES" tag="25" contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1Wn-ab-2Sg">
+                                                    <rect key="frame" x="16" y="383" width="313" height="38"/>
                                                     <subviews>
                                                         <stackView opaque="NO" tag="25" contentMode="scaleToFill" distribution="fillEqually" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Dwt-Xd-gsb">
                                                             <rect key="frame" x="8" y="6" width="298" height="26"/>
@@ -4326,79 +4410,37 @@ You may export the public key descriptor at anytime but the 12 word recovery phr
                                                         <constraint firstItem="Dwt-Xd-gsb" firstAttribute="top" secondItem="1Wn-ab-2Sg" secondAttribute="top" constant="6" id="rbU-8S-OrE"/>
                                                     </constraints>
                                                 </view>
-                                                <switch opaque="NO" tag="2" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1u0-OO-HE9">
-                                                    <rect key="frame" x="15" y="21" width="51" height="31"/>
-                                                </switch>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Created:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ckd-q3-zNx">
-                                                    <rect key="frame" x="16" y="103" width="38" height="11"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="9"/>
-                                                    <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" tag="24" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Active" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oW9-IX-PDE">
-                                                    <rect key="frame" x="72" y="26.5" width="47.5" height="20.5"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" tag="13" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2020-Feb-09 15:48" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xiT-PY-mWf">
-                                                    <rect key="frame" x="241.5" y="103" width="87.5" height="11"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="9"/>
-                                                    <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Updated:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MfD-7G-p6e">
-                                                    <rect key="frame" x="196.5" y="103" width="40.5" height="11"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="9"/>
-                                                    <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" tag="8" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Testnet" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B1v-ZE-lI2">
-                                                    <rect key="frame" x="254" y="23.5" width="75" height="26"/>
-                                                    <color key="backgroundColor" red="0.14014528487774194" green="0.17214550810387905" blue="0.19040927021725895" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="width" constant="75" id="85i-cA-AvM"/>
-                                                        <constraint firstAttribute="height" constant="26" id="Xbq-y2-0Xo"/>
-                                                    </constraints>
-                                                    <fontDescription key="fontDescription" type="system" weight="heavy" pointSize="12"/>
-                                                    <color key="textColor" systemColor="systemOrangeColor" red="1" green="0.58431372550000005" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
                                             </subviews>
                                             <constraints>
                                                 <constraint firstItem="ZsE-bQ-qYq" firstAttribute="top" secondItem="xIK-fc-Mq4" secondAttribute="bottom" constant="8" id="0Fe-tM-RGt"/>
                                                 <constraint firstItem="pII-Us-N4E" firstAttribute="top" secondItem="ZsE-bQ-qYq" secondAttribute="bottom" constant="8" id="1YV-Ms-ht8"/>
                                                 <constraint firstItem="1Wn-ab-2Sg" firstAttribute="bottom" secondItem="EKP-cw-XcR" secondAttribute="bottomMargin" id="21F-IG-Zxg"/>
                                                 <constraint firstItem="oW9-IX-PDE" firstAttribute="centerY" secondItem="1u0-OO-HE9" secondAttribute="centerY" id="5EC-Mw-2Ri"/>
-                                                <constraint firstItem="PjG-od-EAV" firstAttribute="top" secondItem="Ckd-q3-zNx" secondAttribute="bottom" id="5QZ-RT-jBe"/>
                                                 <constraint firstItem="ZsE-bQ-qYq" firstAttribute="leading" secondItem="xIK-fc-Mq4" secondAttribute="leading" id="6lZ-XX-pwM"/>
                                                 <constraint firstItem="xiT-PY-mWf" firstAttribute="leading" secondItem="MfD-7G-p6e" secondAttribute="trailing" constant="4.5" id="9Ik-c9-8Bd"/>
                                                 <constraint firstAttribute="trailing" secondItem="1Wn-ab-2Sg" secondAttribute="trailing" constant="16" id="A1F-mt-vPG"/>
-                                                <constraint firstItem="vmf-kd-EW6" firstAttribute="centerY" secondItem="vbq-pg-bVi" secondAttribute="centerY" id="ASu-wS-ewX"/>
-                                                <constraint firstItem="PjG-od-EAV" firstAttribute="leading" secondItem="EKP-cw-XcR" secondAttribute="leadingMargin" id="B4J-cB-Ctr"/>
+                                                <constraint firstItem="1u0-OO-HE9" firstAttribute="top" secondItem="kho-sl-W6K" secondAttribute="bottom" constant="16" id="BCd-37-WDq"/>
                                                 <constraint firstItem="KGY-cW-hyS" firstAttribute="leading" secondItem="EKP-cw-XcR" secondAttribute="leadingMargin" id="BGH-Bs-hyD"/>
                                                 <constraint firstItem="xIK-fc-Mq4" firstAttribute="top" secondItem="iY3-wV-4kw" secondAttribute="bottom" constant="2" id="BlK-Bx-uOb"/>
                                                 <constraint firstItem="75R-94-8gm" firstAttribute="centerY" secondItem="Ckd-q3-zNx" secondAttribute="centerY" id="CpK-aI-TfZ"/>
                                                 <constraint firstItem="Pie-V8-QKM" firstAttribute="leading" secondItem="EKP-cw-XcR" secondAttribute="leadingMargin" id="Gmd-EU-n77"/>
                                                 <constraint firstItem="iY3-wV-4kw" firstAttribute="leading" secondItem="EKP-cw-XcR" secondAttribute="leadingMargin" constant="1" id="HZe-gV-b13"/>
-                                                <constraint firstItem="vbq-pg-bVi" firstAttribute="centerY" secondItem="PjG-od-EAV" secondAttribute="centerY" id="Hos-ig-U7W"/>
+                                                <constraint firstItem="kho-sl-W6K" firstAttribute="leading" secondItem="EKP-cw-XcR" secondAttribute="leading" id="JJF-lh-J2S"/>
                                                 <constraint firstItem="Pie-V8-QKM" firstAttribute="top" secondItem="pII-Us-N4E" secondAttribute="bottom" constant="8" id="LZS-3W-w7G"/>
-                                                <constraint firstItem="1u0-OO-HE9" firstAttribute="top" secondItem="EKP-cw-XcR" secondAttribute="topMargin" constant="10" id="M6l-iO-VnR"/>
                                                 <constraint firstItem="Ckd-q3-zNx" firstAttribute="leading" secondItem="EKP-cw-XcR" secondAttribute="leading" constant="16" id="NeX-tC-pYW"/>
-                                                <constraint firstItem="iY3-wV-4kw" firstAttribute="top" secondItem="PjG-od-EAV" secondAttribute="bottom" constant="4" id="Sf3-fg-hLt"/>
                                                 <constraint firstItem="ZsE-bQ-qYq" firstAttribute="trailing" secondItem="EKP-cw-XcR" secondAttribute="trailingMargin" id="TWV-oa-u5M"/>
                                                 <constraint firstItem="Ckd-q3-zNx" firstAttribute="top" secondItem="KGY-cW-hyS" secondAttribute="bottom" id="Th2-Z4-huO"/>
+                                                <constraint firstItem="iY3-wV-4kw" firstAttribute="top" secondItem="Ckd-q3-zNx" secondAttribute="bottom" constant="8" id="VUX-G0-X8A"/>
                                                 <constraint firstItem="xiT-PY-mWf" firstAttribute="centerY" secondItem="MfD-7G-p6e" secondAttribute="centerY" id="Vq3-np-hPg"/>
-                                                <constraint firstItem="vbq-pg-bVi" firstAttribute="leading" secondItem="PjG-od-EAV" secondAttribute="trailing" constant="7" id="bLL-hh-acr"/>
                                                 <constraint firstItem="B1v-ZE-lI2" firstAttribute="centerY" secondItem="oW9-IX-PDE" secondAttribute="centerY" id="bjP-a5-odQ"/>
                                                 <constraint firstItem="pII-Us-N4E" firstAttribute="trailing" secondItem="xIK-fc-Mq4" secondAttribute="trailing" id="cWG-mP-Pwz"/>
                                                 <constraint firstItem="75R-94-8gm" firstAttribute="leading" secondItem="Ckd-q3-zNx" secondAttribute="trailing" constant="2" id="ddk-jQ-Db9"/>
+                                                <constraint firstAttribute="trailing" secondItem="kho-sl-W6K" secondAttribute="trailing" id="dui-ac-HlT"/>
+                                                <constraint firstItem="kho-sl-W6K" firstAttribute="top" secondItem="EKP-cw-XcR" secondAttribute="top" id="eMO-Ud-rWa"/>
                                                 <constraint firstItem="xIK-fc-Mq4" firstAttribute="leading" secondItem="EKP-cw-XcR" secondAttribute="leadingMargin" constant="1" id="hjh-Hy-gbg"/>
                                                 <constraint firstItem="xIK-fc-Mq4" firstAttribute="trailing" secondItem="EKP-cw-XcR" secondAttribute="trailingMargin" id="kKX-cS-AQB"/>
                                                 <constraint firstAttribute="trailingMargin" secondItem="B1v-ZE-lI2" secondAttribute="trailing" constant="1" id="kTH-ux-lwu"/>
                                                 <constraint firstItem="1u0-OO-HE9" firstAttribute="leading" secondItem="EKP-cw-XcR" secondAttribute="leadingMargin" id="kpo-4z-CDx"/>
-                                                <constraint firstItem="fPC-rc-FTn" firstAttribute="leading" secondItem="vmf-kd-EW6" secondAttribute="trailing" constant="12" id="mbC-eI-sWw"/>
-                                                <constraint firstAttribute="trailingMargin" secondItem="fPC-rc-FTn" secondAttribute="trailing" constant="1" id="mcC-BX-xmt"/>
                                                 <constraint firstItem="pII-Us-N4E" firstAttribute="leading" secondItem="xIK-fc-Mq4" secondAttribute="leading" id="ody-oO-aUD"/>
                                                 <constraint firstAttribute="trailing" secondItem="xiT-PY-mWf" secondAttribute="trailing" constant="16" id="otd-jJ-klc"/>
                                                 <constraint firstItem="1Wn-ab-2Sg" firstAttribute="leading" secondItem="EKP-cw-XcR" secondAttribute="leading" constant="16" id="p5K-D3-3rP"/>
@@ -4408,10 +4450,9 @@ You may export the public key descriptor at anytime but the 12 word recovery phr
                                                 <constraint firstItem="oW9-IX-PDE" firstAttribute="leading" secondItem="1u0-OO-HE9" secondAttribute="trailing" constant="8" id="v6r-JI-N7m"/>
                                                 <constraint firstItem="MfD-7G-p6e" firstAttribute="centerY" secondItem="75R-94-8gm" secondAttribute="centerY" id="vnn-dw-xcE"/>
                                                 <constraint firstAttribute="trailing" secondItem="KGY-cW-hyS" secondAttribute="trailing" constant="15" id="ydq-J3-1yi"/>
-                                                <constraint firstItem="fPC-rc-FTn" firstAttribute="centerY" secondItem="vbq-pg-bVi" secondAttribute="centerY" id="zwq-Qb-i6c"/>
                                             </constraints>
                                         </tableViewCellContentView>
-                                        <color key="backgroundColor" red="0.10745384561869913" green="0.1295574761362753" blue="0.14178569119751272" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="backgroundColor" red="0.089769794811718012" green="0.10632825981529986" blue="0.12038902404213192" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </tableViewCell>
                                 </prototypes>
                                 <connections>
@@ -4442,10 +4483,10 @@ You may export the public key descriptor at anytime but the 12 word recovery phr
                             <constraint firstItem="JXW-QX-3AG" firstAttribute="leading" secondItem="DAO-kd-lrb" secondAttribute="leading" id="3Bh-zG-WUa"/>
                             <constraint firstItem="A9T-7X-AAd" firstAttribute="leading" secondItem="DAO-kd-lrb" secondAttribute="leading" constant="16" id="DSg-KN-eRY"/>
                             <constraint firstItem="uwf-dq-G76" firstAttribute="leading" secondItem="A9T-7X-AAd" secondAttribute="trailing" constant="8" id="ErK-Q6-0nD"/>
-                            <constraint firstItem="JXW-QX-3AG" firstAttribute="top" secondItem="uwf-dq-G76" secondAttribute="bottom" constant="12" id="IFb-g6-yig"/>
+                            <constraint firstItem="JXW-QX-3AG" firstAttribute="top" secondItem="uwf-dq-G76" secondAttribute="bottom" constant="4" id="IFb-g6-yig"/>
                             <constraint firstItem="uwf-dq-G76" firstAttribute="top" secondItem="DAO-kd-lrb" secondAttribute="top" constant="5" id="JKu-2r-Lbf"/>
                             <constraint firstItem="uwf-dq-G76" firstAttribute="centerY" secondItem="A9T-7X-AAd" secondAttribute="centerY" id="JRO-H7-gIZ"/>
-                            <constraint firstItem="DAO-kd-lrb" firstAttribute="bottom" secondItem="JXW-QX-3AG" secondAttribute="bottom" id="Rq9-6W-JXU"/>
+                            <constraint firstItem="DAO-kd-lrb" firstAttribute="bottom" secondItem="JXW-QX-3AG" secondAttribute="bottom" constant="-1" id="Rq9-6W-JXU"/>
                             <constraint firstItem="DAO-kd-lrb" firstAttribute="trailing" secondItem="JXW-QX-3AG" secondAttribute="trailing" id="dyM-Qi-mfh"/>
                             <constraint firstItem="A9T-7X-AAd" firstAttribute="top" secondItem="DAO-kd-lrb" secondAttribute="top" constant="9.5" id="qFI-ig-GcG"/>
                         </constraints>
@@ -5021,7 +5062,9 @@ You may export the public key descriptor at anytime but the 12 word recovery phr
         <image name="doc.on.doc" catalog="system" width="58" height="64"/>
         <image name="dot.radiowaves.left.and.right" catalog="system" width="64" height="44"/>
         <image name="eye" catalog="system" width="64" height="40"/>
+        <image name="eye.fill" catalog="system" width="64" height="38"/>
         <image name="eyeglasses" catalog="system" width="64" height="26"/>
+        <image name="flame" catalog="system" width="54" height="64"/>
         <image name="folder.circle" catalog="system" width="64" height="60"/>
         <image name="gear" catalog="system" width="64" height="58"/>
         <image name="greenCircle.png" width="90" height="90"/>
@@ -5038,9 +5081,11 @@ You may export the public key descriptor at anytime but the 12 word recovery phr
         <image name="qrcode" catalog="system" width="64" height="56"/>
         <image name="qrcode.viewfinder" catalog="system" width="64" height="56"/>
         <image name="rectangle.stack" catalog="system" width="64" height="60"/>
+        <image name="snow" catalog="system" width="60" height="64"/>
         <image name="speaker.3" catalog="system" width="64" height="44"/>
         <image name="square.and.arrow.up" catalog="system" width="56" height="64"/>
         <image name="square.stack.3d.down.right" catalog="system" width="62" height="64"/>
+        <image name="sun.min" catalog="system" width="64" height="60"/>
         <image name="text.bubble" catalog="system" width="64" height="54"/>
         <image name="thermometer.snowflake" catalog="system" width="56" height="64"/>
         <image name="timer" catalog="system" width="64" height="60"/>
@@ -5052,7 +5097,7 @@ You may export the public key descriptor at anytime but the 12 word recovery phr
         <segue reference="rrW-6B-Fka"/>
         <segue reference="tY7-Ss-m0T"/>
         <segue reference="LzA-tD-DJD"/>
-        <segue reference="0zN-S6-Zr1"/>
+        <segue reference="r5v-RV-hIL"/>
     </inferredMetricsTieBreakers>
     <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
 </document>

--- a/FullyNoded2/FullyNoded2/SceneDelegate.swift
+++ b/FullyNoded2/FullyNoded2/SceneDelegate.swift
@@ -40,6 +40,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Called as the scene transitions from the background to the foreground.
         // Use this method to undo the changes made on entering the background.
         
+        // Disable Sign In with Apple on simulator
+        #if !targetEnvironment(simulator)
+        
         DispatchQueue.main.async {
             
             let storyboard = UIStoryboard(name: "Main", bundle: nil)
@@ -54,75 +57,28 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             }
             
         }
-
         
-//        if let userIdentifier = keychain.get("userIdentifier1") {
-//
-//            let authorizationProvider = ASAuthorizationAppleIDProvider()
-//            authorizationProvider.getCredentialState(forUserID: userIdentifier) { (state, error) in
-//
-//
-//
-//            }
-//
-//        } else {
-//
-//            showLogIn()
-//
-//        }
+        #endif
         
         NotificationCenter.default.post(name: .didEnterForeground, object: nil, userInfo: nil)
         
         let enc = Encryption()
         enc.getNode { (node, error) in
             
-            if !error && node != nil {
+            if !error && node != nil && !TorClient.sharedInstance.isOperational {
                 
-                TorClient.sharedInstance.isRefreshing = true
-                
-                TorClient.sharedInstance.start {
-                    
-                    print("start tor")
-                    
-                    
-                }
+                TorClient.sharedInstance.start {}
                 
             }
             
         }
+        
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {
         // Called as the scene transitions from the foreground to the background.
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.
-        
-//        let fileManager = FileManager.default
-//        let authPath = URL(fileURLWithPath: self.getTorPath(), isDirectory: true).appendingPathComponent("onion_auth", isDirectory: true).path
-//
-//        do {
-//
-//            let filePaths = try fileManager.contentsOfDirectory(atPath: authPath)
-//
-//            for filePath in filePaths {
-//
-//                let url = URL(fileURLWithPath: authPath + "/" + filePath)
-//                try fileManager.removeItem(at: url)
-//                print("deleted key")
-//
-//            }
-//
-//        } catch {
-//
-//            print("error deleting auth keys file")
-//
-//        }
-        
-        //if UIDevice.modelName != "iPhone 11 pro max" && UIDevice.modelName != "Simulator iPhone 11 pro max" {
-            
-            TorClient.sharedInstance.resign()
-            
-        //}
 
         // Save changes in the application's managed object context when the application transitions to the background.
         (UIApplication.shared.delegate as? AppDelegate)?.saveContext()
@@ -167,29 +123,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
         
     }
-    
-//    private func getTorPath() -> String {
-//        print("getTorPath")
-//
-//        var torDirectory = ""
-//
-//        #if targetEnvironment(simulator)
-//        print("is simulator")
-//
-//        let path = NSSearchPathForDirectoriesInDomains(.applicationDirectory, .userDomainMask, true).first ?? ""
-//        torDirectory = "\(path.split(separator: Character("/"))[0..<2].joined(separator: "/"))/.tor_tmp"
-//
-//        #else
-//        print("is device")
-//
-//        torDirectory = "\(NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true).first ?? "")/tor"
-//
-//        #endif
-//
-//        return torDirectory
-//
-//    }
-
 
 }
 

--- a/FullyNoded2/FullyNoded2/Structs/DescriptorStruct.swift
+++ b/FullyNoded2/FullyNoded2/Structs/DescriptorStruct.swift
@@ -16,6 +16,13 @@ public struct DescriptorStruct: CustomStringConvertible {
     let chain:String
     let isMulti:Bool
     let isBIP67:Bool
+    let isBIP49:Bool
+    let isBIP84:Bool
+    let isBIP44:Bool
+    let isP2WPKH:Bool
+    let isP2PKH:Bool
+    let isP2SHP2WPKH:Bool
+    let network:String
     
     init(dictionary: [String: Any]) {
         
@@ -25,6 +32,13 @@ public struct DescriptorStruct: CustomStringConvertible {
         self.chain = dictionary["chain"] as? String ?? ""
         self.isMulti = dictionary["isMulti"] as? Bool ?? false
         self.isBIP67 = dictionary["isBIP67"] as? Bool ?? false
+        self.isBIP49 = dictionary["isBIP49"] as? Bool ?? false
+        self.isBIP84 = dictionary["isBIP84"] as? Bool ?? false
+        self.isBIP44 = dictionary["isBIP44"] as? Bool ?? false
+        self.isP2PKH = dictionary["isP2PKH"] as? Bool ?? false
+        self.isP2WPKH = dictionary["isP2WPKH"] as? Bool ?? false
+        self.isP2SHP2WPKH = dictionary["isP2SHP2WPKH"] as? Bool ?? false
+        self.network = dictionary["network"] as? String ?? ""
         
     }
     

--- a/FullyNoded2/FullyNoded2/Sub Views/Alert View/ErrorView.swift
+++ b/FullyNoded2/FullyNoded2/Sub Views/Alert View/ErrorView.swift
@@ -13,14 +13,13 @@ class ErrorView: UIView, UIGestureRecognizerDelegate {
     
     let errorLabel = UILabel()
     let impact = UIImpactFeedbackGenerator()
-    let upSwipe = UISwipeGestureRecognizer()
+    //let upSwipe = UISwipeGestureRecognizer()
     let backgroundView = UIVisualEffectView(effect: UIBlurEffect(style: .dark))
     let tap = UITapGestureRecognizer()
     let infoButton = UIButton()
     let infoTitle = ""
     let infoDetail = ""
     var action = {}
-    //myView.addGestureRecognizer(tap)
     
     
     @objc func handleTap(_ sender: UIGestureRecognizer) {
@@ -29,13 +28,13 @@ class ErrorView: UIView, UIGestureRecognizerDelegate {
         
     }
     
-    @objc func handleSwipes(_ sender: UIGestureRecognizer) {
-        
-        print("handleSwipes")
-     
-        hide()
-        
-    }
+//    @objc func handleSwipes(_ sender: UIGestureRecognizer) {
+//
+//        print("handleSwipes")
+//
+//        hide()
+//
+//    }
     
     func hide() {
         
@@ -85,23 +84,19 @@ class ErrorView: UIView, UIGestureRecognizerDelegate {
         tap.delegate = self
         //tap.cancelsTouchesInView = false
         self.isUserInteractionEnabled = true
-        upSwipe.direction = .up
-        upSwipe.addTarget(self, action: #selector(handleSwipes(_:)))
-        //backgroundView.addGestureRecognizer(self.upSwipe)
-        //tap.addTarget(target: self, action: #selector(self.handleTap(_:)))
+        //upSwipe.direction = .up
+        //upSwipe.addTarget(self, action: #selector(handleSwipes(_:)))
         tap.addTarget(self, action: #selector(self.handleTap(_:)))
         backgroundView.addGestureRecognizer(self.tap)
         
-        let width = vc.view.frame.width
+        let width = vc.view.frame.width - 32
         
         backgroundView.frame = CGRect(x: 0,
                                       y: -61,
-                                      width: width,
+                                      width: vc.view.frame.width,
                                       height: 61)
         
         backgroundView.alpha = 0
-        
-        
         
         if isError {
             
@@ -115,7 +110,7 @@ class ErrorView: UIView, UIGestureRecognizerDelegate {
         
         errorLabel.frame = CGRect(x: 16,
                                   y: -61,
-                                  width: width - 32,
+                                  width: width,
                                   height: 61)
         
         errorLabel.font = UIFont.systemFont(ofSize: 12)
@@ -123,7 +118,7 @@ class ErrorView: UIView, UIGestureRecognizerDelegate {
         errorLabel.numberOfLines = 0
         errorLabel.textAlignment = .left
         
-        infoButton.frame = CGRect(x: errorLabel.frame.maxX - 30, y: (errorLabel.frame.height / 2) - 10, width: 20, height: 20)
+        infoButton.frame = CGRect(x: backgroundView.frame.maxX - 30, y: (backgroundView.frame.height / 2) - 10, width: 20, height: 20)
         infoButton.target(forAction: #selector(showInfo), withSender: self)
         
         if isError {
@@ -141,57 +136,42 @@ class ErrorView: UIView, UIGestureRecognizerDelegate {
             
         }
         
-        errorLabel.addSubview(infoButton)
+        //errorLabel.addSubview(infoButton)
         
         backgroundView.contentView.addSubview(errorLabel)
+        backgroundView.contentView.addSubview(infoButton)
         
         vc.view.addSubview(backgroundView)
         
-        //let imageView = UIImageView()
-        //imageView.backgroundColor = UIColor.clear
-        //imageView.image = UIImage(named: "Image-12")
+        var y = CGFloat()
+        
+        if vc.navigationController != nil {
+            
+            y = vc.navigationController!.navigationBar.frame.maxY
+            
+        } else {
+            
+            y = 0
+            
+        }
         
         UIView.animate(withDuration: 0.3, animations: {
             
             self.backgroundView.alpha = 1
             
-            if vc.navigationController != nil {
-                
-                self.backgroundView.frame = CGRect(x: 0,
-                                                   y: 61,
-                                                   width: width,
-                                                   height: 61)
-                
-                self.errorLabel.frame = CGRect(x: 16,
-                                               y: 0,
-                                               width: width,
+            self.backgroundView.frame = CGRect(x: 0,
+                                               y: y,
+                                               width: vc.view.frame.width,
                                                height: 61)
-                
-            } else {
-               
-                self.backgroundView.frame = CGRect(x: 0,
-                                                   y: 0,
-                                                   width: width,
-                                                   height: 61)
-                
-                self.errorLabel.frame = CGRect(x: 16,
-                                               y: 0,
-                                               width: width,
-                                               height: 61)
-                
-            }
+            
+            self.errorLabel.frame = CGRect(x: 16,
+                                           y: 0,
+                                           width: width,
+                                           height: 61)
             
         }) { _ in
             
             DispatchQueue.main.async {
-                
-                //imageView.alpha = 0.2
-//                imageView.frame = CGRect(x: self.errorLabel.frame.midX - 15,
-//                                         y: self.errorLabel.frame.maxY - 18,
-//                                         width: 20,
-//                                         height: 20)
-                
-                //self.errorLabel.addSubview(imageView)
                 
                 self.impact.impactOccurred()
                 

--- a/FullyNoded2/FullyNoded2/Sub Views/Raw Transaction Displayer/RawDisplayer.swift
+++ b/FullyNoded2/FullyNoded2/Sub Views/Raw Transaction Displayer/RawDisplayer.swift
@@ -15,10 +15,10 @@ class RawDisplayer {
     let textView = UITextView()
     var qrView = UIImageView()
     let qrGenerator = QRGenerator()
-    let backgroundView = UIView()
+    //let backgroundView = UIView()
     let copiedLabel = UILabel()
     //var navigationBar = UINavigationBar()
-    var tabbar = UITabBar()
+    //var tabbar = UITabBar()
     var vc = UIViewController()
     var rawString = ""
     let impact = UIImpactFeedbackGenerator()
@@ -27,7 +27,7 @@ class RawDisplayer {
         
         //tabbar = vc.tabBarController!.tabBar
         //navigationBar = vc.navigationController!.navigationBar
-        configureBackground()
+        //configureBackground()
         configureQrView()
         configureTextView()
         configureCopiedLabel()
@@ -36,13 +36,13 @@ class RawDisplayer {
         textView.text = rawString
         UIPasteboard.general.string = rawString
         
-        backgroundView.addSubview(qrView)
-        backgroundView.addSubview(textView)
-        vc.view.addSubview(backgroundView)
+        vc.view.addSubview(qrView)
+        vc.view.addSubview(textView)
+        //vc.view.addSubview(backgroundView)
         
         UIView.animate(withDuration: 0.2, animations: {
             
-            self.backgroundView.alpha = 1
+            //self.backgroundView.alpha = 1
             
         }) { _ in
             
@@ -169,13 +169,13 @@ class RawDisplayer {
         
     }
     
-    func configureBackground() {
-        
-        backgroundView.alpha = 0
-        backgroundView.backgroundColor = UIColor.clear
-        backgroundView.frame = vc.view.frame
-        
-    }
+//    func configureBackground() {
+//
+//        backgroundView.alpha = 0
+//        backgroundView.backgroundColor = UIColor.clear
+//        backgroundView.frame = vc.view.frame
+//
+//    }
     
     func generateQrCode(key: String) -> UIImage {
         

--- a/FullyNoded2/FullyNoded2/View Controllers/Home Screen/ImportViewController.swift
+++ b/FullyNoded2/FullyNoded2/View Controllers/Home Screen/ImportViewController.swift
@@ -139,7 +139,7 @@ class ImportViewController: UIViewController, UINavigationControllerDelegate {
         
         connectingView.addConnectingView(vc: self, description: "creating custom wallet")
         
-        let importWallet = ImportColdMultiSigDescriptor()
+        let importWallet = ImportCustomDescriptor()
         importWallet.create(descriptor: url) { (success, error, errorDescription) in
             
             if !error && success {

--- a/FullyNoded2/FullyNoded2/View Controllers/Home Screen/MainMenuViewController.swift
+++ b/FullyNoded2/FullyNoded2/View Controllers/Home Screen/MainMenuViewController.swift
@@ -1367,8 +1367,16 @@ class MainMenuViewController: UIViewController, UITableViewDelegate, UITableView
     
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         
-        return 30
-        
+        if section <= 3 {
+            
+            return 30
+            
+        } else {
+            
+            return 10
+            
+        }
+                
     }
     
     private func walletCellHeight() -> CGFloat {
@@ -1938,23 +1946,33 @@ class MainMenuViewController: UIViewController, UITableViewDelegate, UITableView
                                 
                 DispatchQueue.main.async {
                     
-                    if self.transactionArray.count > 0 {
-
-                        for (i, _) in self.transactionArray.enumerated() {
-
-                            self.reloadSections([i + 3])
-
-                        }
-                        //self.mainMenu.reloadData()
-
-                    } else {
-
-                        self.reloadSections([3])
-
-                    }
-                    //self.mainMenu.reloadData()
+//                    if self.transactionArray.count > 0 {
+//
+//                        for (i, _) in self.transactionArray.enumerated() {
+//
+//                            self.reloadSections([i + 3])
+//
+//                            if i + 1 == self.transactionArray.count {
+//
+//                                self.impact()
+//                                self.loadNodeData()
+//
+//                            }
+//
+//                        }
+//
+//                    } else {
+//
+//                        self.reloadSections([3])
+//                        self.impact()
+//                        self.loadNodeData()
+//
+//                    }
+                    
                     self.impact()
+                    self.mainMenu.reloadData()
                     self.loadNodeData()
+                    
                     
                 }
                 
@@ -1988,23 +2006,24 @@ class MainMenuViewController: UIViewController, UITableViewDelegate, UITableView
                                 
                 DispatchQueue.main.async {
                     
-                    if self.transactionArray.count > 1 {
-                        
-                        for (i, _) in self.transactionArray.enumerated() {
-                            
-                            self.reloadSections([i + 3])
-                            
-                        }
-                        
-                        //
-                        self.mainMenu.reloadData()
-                        
-                    } else {
-                        
-                        self.reloadSections([3])
-                        
-                    }
+//                    if self.transactionArray.count > 1 {
+//
+//                        for (i, _) in self.transactionArray.enumerated() {
+//
+//                            self.reloadSections([i + 3])
+//
+//                        }
+//
+//                        //
+//                        self.mainMenu.reloadData()
+//
+//                    } else {
+//
+//                        self.reloadSections([3])
+//
+//                    }
                     
+                    self.mainMenu.reloadData()
                     self.impact()
                     
                 }

--- a/FullyNoded2/FullyNoded2/View Controllers/Home Screen/MainMenuViewController.swift
+++ b/FullyNoded2/FullyNoded2/View Controllers/Home Screen/MainMenuViewController.swift
@@ -82,7 +82,6 @@ class MainMenuViewController: UIViewController, UITableViewDelegate, UITableView
         navigationController?.delegate = self
         NotificationCenter.default.addObserver(self, selector: #selector(self.notificationReceived(_:)), name: .torConnecting, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(self.foregroundNotificationReceived(_:)), name: .didEnterForeground, object: nil)
-        //mainMenu.tableFooterView = UIView(frame: .zero)
         initialLoad = true
         walletSectionLoaded = false
         torSectionLoaded = false
@@ -126,6 +125,11 @@ class MainMenuViewController: UIViewController, UITableViewDelegate, UITableView
             }
             
         }
+        
+        let p = DescriptorParser()
+        let s = p.descriptor("wpkh(tpubDEVbsU2HhhyMWRfMiX4gEJRk9e5V19V6n9RwmhE9oP6QtkU2pSR8c4GHxV2WBX36TSyjx9kcA89fAnm4QVGJRbchXSx9iBBAvvUDRCgaLDY/*)")
+        print("s.ismulti = \(s.isMulti)")
+        
                 
     }
     
@@ -154,20 +158,20 @@ class MainMenuViewController: UIViewController, UITableViewDelegate, UITableView
     @objc func foregroundNotificationReceived(_ notification: Notification) {
         print("foreground NotificationReceived")
         
-        if UIDevice.modelName != "iPhone 11 pro max" && UIDevice.modelName != "Simulator iPhone 11 pro max" {
-            
-            self.torConnected = false
-            self.reloadSections([1])
-            
-        } else {
-            
-            if !initialLoad {
-                
-                showAlert(vc: self, title: "Alert", message: "There is a known issue when refreshing the Tor connection on iPhone 11 Pro Max, we are working on a fix, in the meantime you may need to force close the app and reopen to reconnect Tor manually if you experience any issues.")
-                
-            }
-            
-        }
+//        if UIDevice.modelName != "iPhone 11 pro max" && UIDevice.modelName != "Simulator iPhone 11 pro max" {
+//
+//            self.torConnected = false
+//            self.reloadSections([1])
+//
+//        } else {
+//
+//            if !initialLoad {
+//
+//                showAlert(vc: self, title: "Alert", message: "There is a known issue when refreshing the Tor connection on iPhone 11 Pro Max, we are working on a fix, in the meantime you may need to force close the app and reopen to reconnect Tor manually if you experience any issues.")
+//
+//            }
+//
+//        }
 
     }
     
@@ -410,13 +414,16 @@ class MainMenuViewController: UIViewController, UITableViewDelegate, UITableView
         
         dirtyFiatLabel.text = "\(self.fiatBalance)"
         
-        if network == "test" {
-            
-            coldBalanceLabel.textColor = .systemOrange
-            
-        } else if network == "main" {
+        let parser = DescriptorParser()
+        let str = parser.descriptor(wallet.descriptor)
+        
+        if str.chain == "Mainnet" {
             
             coldBalanceLabel.textColor = .systemGreen
+            
+        } else if str.chain == "Testnet" {
+            
+            coldBalanceLabel.textColor = .systemOrange
             
         }
         
@@ -434,7 +441,7 @@ class MainMenuViewController: UIViewController, UITableViewDelegate, UITableView
             
         } else {
             
-            confirmedIcon.image = UIImage(systemName: "checkmark.circle")
+            confirmedIcon.image = UIImage(systemName: "checkmark")
             confirmedIcon.tintColor = .systemGreen
             
         }
@@ -518,13 +525,16 @@ class MainMenuViewController: UIViewController, UITableViewDelegate, UITableView
         
         dirtyFiatLabel.text = "\(self.fiatBalance)"
         
-        if network == "test" {
-            
-            coldBalanceLabel.textColor = .systemOrange
-            
-        } else if network == "main" {
+        let parser = DescriptorParser()
+        let str = parser.descriptor(wallet.descriptor)
+        
+        if str.chain == "Mainnet" {
             
             coldBalanceLabel.textColor = .systemGreen
+            
+        } else if str.chain == "Testnet" {
+            
+            coldBalanceLabel.textColor = .systemOrange
             
         }
         
@@ -537,7 +547,7 @@ class MainMenuViewController: UIViewController, UITableViewDelegate, UITableView
             
         } else {
             
-            confirmedIcon.image = UIImage(systemName: "checkmark.circle")
+            confirmedIcon.image = UIImage(systemName: "checkmark")
             confirmedIcon.tintColor = .systemGreen
             
         }
@@ -624,13 +634,16 @@ class MainMenuViewController: UIViewController, UITableViewDelegate, UITableView
         
         dirtyFiatLabel.text = "\(self.fiatBalance)"
         
-        if network == "test" {
-            
-            coldBalanceLabel.textColor = .systemOrange
-            
-        } else if network == "main" {
+        let parser = DescriptorParser()
+        let str = parser.descriptor(wallet.descriptor)
+        
+        if str.chain == "Mainnet" {
             
             coldBalanceLabel.textColor = .systemGreen
+            
+        } else if str.chain == "Testnet" {
+            
+            coldBalanceLabel.textColor = .systemOrange
             
         }
         
@@ -643,7 +656,7 @@ class MainMenuViewController: UIViewController, UITableViewDelegate, UITableView
             
         } else {
             
-            confirmedIcon.image = UIImage(systemName: "checkmark.circle")
+            confirmedIcon.image = UIImage(systemName: "checkmark")
             confirmedIcon.tintColor = .systemGreen
             
         }
@@ -787,13 +800,13 @@ class MainMenuViewController: UIViewController, UITableViewDelegate, UITableView
             
         } else {
             
-            torStatusLabel.text = "connecting..."
-            torActiveCircle.tintColor = .systemOrange
+            torStatusLabel.text = "disconnected..."
+            torActiveCircle.tintColor = .systemRed
             connectionStatusLabel.text = "disconnected..."
             
-            spinner.startAnimating()
-            spinner.alpha = 1
-            infoButton.alpha = 0
+            spinner.stopAnimating()
+            spinner.alpha = 0
+            infoButton.alpha = 1
             
         }
         
@@ -1827,7 +1840,7 @@ class MainMenuViewController: UIViewController, UITableViewDelegate, UITableView
                         
                     } else {
                         
-                        self.reloadSections([self.nodeCellIndex, self.walletCellIndex])
+                        self.reloadSections([self.nodeCellIndex])
                         
                     }
                     
@@ -1939,7 +1952,7 @@ class MainMenuViewController: UIViewController, UITableViewDelegate, UITableView
                         self.reloadSections([3])
 
                     }
-                    self.mainMenu.reloadData()
+                    //self.mainMenu.reloadData()
                     self.impact()
                     self.loadNodeData()
                     

--- a/FullyNoded2/FullyNoded2/View Controllers/Home Screen/ScannerViewController.swift
+++ b/FullyNoded2/FullyNoded2/View Controllers/Home Screen/ScannerViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import LibWally
 
 class ScannerViewController: UIViewController, UINavigationControllerDelegate {
     
@@ -155,6 +156,105 @@ class ScannerViewController: UIViewController, UINavigationControllerDelegate {
         
     }
     
+    func signPSBT(psbt: String) {
+        
+        //let decodedData = Data(base64Encoded: psbt)!
+        let cd = CoreDataService()
+        cd.retrieveEntity(entityName: .wallets) { (wallets, errorDescription) in
+            if errorDescription == nil && wallets != nil {
+                for w in wallets! {
+                    let wallet = WalletStruct(dictionary: w)
+                    let chain = network(path: wallet.derivation)
+                    print("chain = \(chain)")
+                    do {
+                        var localPSBT = try PSBT(psbt, chain)
+                        let inputs = localPSBT.inputs
+                        print("inputs.count = \(inputs.count)")
+                        for input in inputs {
+                            let origins = input.origins
+                            for origin in origins! {
+                                var path = origin.value.path
+                                print("path = \(path)")
+                                let s = (path.description).replacingOccurrences(of: "m", with: "")
+                                path = BIP32Path(s)!
+                                let encryptedSeed = wallet.seed
+                                if String(bytes: encryptedSeed, encoding: .utf8) != "no seed" {
+                                    let enc = Encryption()
+                                    enc.decryptData(dataToDecrypt: encryptedSeed) { (seed) in
+                                        if seed != nil {
+                                            if let words = String(data: seed!, encoding: .utf8) {
+                                                let mnenomicCreator = MnemonicCreator()
+                                                mnenomicCreator.convert(words: words) { (mnemonic, error) in
+                                                    if !error {
+                                                        if let masterKey = HDKey(mnemonic!.seedHex(""), network(path: wallet.derivation)) {
+                                                            if let walletPath = BIP32Path(wallet.derivation) {
+                                                                do {
+                                                                    let account = try masterKey.derive(walletPath)
+                                                                    print("account xpub = \(account.xpub)")
+                                                                    do {
+                                                                        let key = try account.derive(path)
+                                                                        //if input.canSign(account) {
+                                                                            if let privkey = key.privKey {
+                                                                                //print("privkey = \(privkey.wif)")
+                                                                                let mk = masterKey.xpriv!
+                                                                                let hdkey = HDKey(mk)
+                                                                                localPSBT.sign(hdkey!)
+                                                                                print("psbt signed")
+                                                                                let final = localPSBT.finalize()
+                                                                                let complete = localPSBT.complete
+                                                                                
+                                                                                if final {
+                                                                                    
+                                                                                    if complete {
+                                                                                        
+                                                                                        if let hex = localPSBT.transactionFinal?.description {
+                                                                                            
+                                                                                            print("complete: \(hex)")
+                                                                                            
+                                                                                        } else {
+                                                                                            
+                                                                                            print("incomplete")
+                                                                                            
+                                                                                        }
+                                                                                        
+                                                                                    }
+                                                                                    
+                                                                                }
+                                                                                
+                                                                            }
+//                                                                        } else {
+//                                                                            print("can't sign with that key")
+//                                                                        }
+                                                                    } catch {
+                                                                        print("error deriving key")
+                                                                    }
+                                                                } catch {
+                                                                    print("error deriving account")
+                                                                }
+                                                            }
+                                                            
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    } catch {
+                        
+                        
+                    }
+                    
+                }
+                
+            }
+            
+        }
+        
+    }
+    
     func addBtcRpcQr(url: String) {
         
         let qc = QuickConnect()
@@ -196,12 +296,16 @@ class ScannerViewController: UIViewController, UINavigationControllerDelegate {
             
             addnode()
             
+        } else if let _ = Data(base64Encoded: url) {
+            
+            signPSBT(psbt: url)
+            
         } else {
             
             
             displayAlert(viewController: self,
                          isError: true,
-                         message: "Thats not a compatible url!")
+                         message: "That's not a compatible QR Code!")
             
         }
                 
@@ -222,4 +326,22 @@ class ScannerViewController: UIViewController, UINavigationControllerDelegate {
         
     }
 
+}
+
+extension String {
+//: ### Base64 encoding a string
+    func base64Encoded() -> String? {
+        if let data = self.data(using: .utf8) {
+            return data.base64EncodedString()
+        }
+        return nil
+    }
+
+//: ### Base64 decoding a string
+    func base64Decoded() -> String? {
+        if let data = Data(base64Encoded: self, options: .ignoreUnknownCharacters) {
+            return String(data: data, encoding: .utf8)
+        }
+        return nil
+    }
 }

--- a/FullyNoded2/FullyNoded2/View Controllers/Incoming/Invoice/InvoiceViewController.swift
+++ b/FullyNoded2/FullyNoded2/View Controllers/Incoming/Invoice/InvoiceViewController.swift
@@ -172,19 +172,20 @@ class InvoiceViewController: UIViewController, UITextFieldDelegate {
         
     }
     
-    func filterDerivation(derivation: String) {
+    func filterDerivation(str: DescriptorStruct) {
+        print("derivation")
         
-        if derivation.contains("84") {
-            
-            self.executeNodeCommand(method: .getnewaddress,
-                                    param: "\"\", \"bech32\"")
-            
-        } else if derivation.contains("44") {
+        if str.isP2PKH || str.isBIP44 || wallet.derivation.contains("44") {
             
             self.executeNodeCommand(method: .getnewaddress,
                                     param: "\"\", \"legacy\"")
             
-        } else if derivation.contains("49") {
+        } else if str.isP2WPKH || str.isBIP84 || wallet.derivation.contains("84")  {
+            
+            self.executeNodeCommand(method: .getnewaddress,
+                                    param: "\"\", \"bech32\"")
+            
+        } else if str.isP2SHP2WPKH || str.isBIP49 || wallet.derivation.contains("49")  {
             
             self.executeNodeCommand(method: .getnewaddress,
                                     param: "\"\", \"p2sh-segwit\"")
@@ -194,8 +195,9 @@ class InvoiceViewController: UIViewController, UITextFieldDelegate {
     }
     
     func showAddress() {
+        print("showAddress")
         
-        let derivation = wallet!.derivation
+        //let derivation = wallet!.derivation
         //let type = wallet!.type
         let parser = DescriptorParser()
         let str = parser.descriptor(wallet!.descriptor)
@@ -206,7 +208,7 @@ class InvoiceViewController: UIViewController, UITextFieldDelegate {
             
         } else {
             
-            self.filterDerivation(derivation: derivation)
+            self.filterDerivation(str: str)
             
         }
         
@@ -224,6 +226,7 @@ class InvoiceViewController: UIViewController, UITextFieldDelegate {
     }
     
     func getMsigAddress() {
+        print("getMsigAddress")
         
         let keyFetcher = KeyFetcher()
         keyFetcher.musigAddress { (address, error) in

--- a/FullyNoded2/FullyNoded2/View Controllers/Outgoing/Raw Tx/CreateRawTxViewController.swift
+++ b/FullyNoded2/FullyNoded2/View Controllers/Outgoing/Raw Tx/CreateRawTxViewController.swift
@@ -596,6 +596,19 @@ class CreateRawTxViewController: UIViewController, UITextFieldDelegate, UITableV
         
     }
     
+    override func viewDidDisappear(_ animated: Bool) {
+        
+        amount = ""
+        addressInput.text = ""
+        outputs.removeAll()
+        outputArray.removeAll()
+        outputsString = ""
+        outputsTable.reloadData()
+        rawTxSigned = ""
+        outputsTable.alpha = 0
+        
+    }
+    
     //MARK: Helpers
     
     func rounded(number: Double) -> Double {
@@ -708,6 +721,7 @@ class CreateRawTxViewController: UIViewController, UITextFieldDelegate, UITableV
     }
     
     func createMultiSig(wallet: WalletStruct) {
+        print("createMultiSig")
         
         var amount = Double()
         for output in outputArray {
@@ -749,13 +763,18 @@ class CreateRawTxViewController: UIViewController, UITextFieldDelegate, UITableV
     }
     
     func createSingleSig() {
+        print("createSingleSig")
         
         let builder = SingleSigBuilder()
-        builder.build(outputs: outputs) { (signedTx, errorDescription) in
+        builder.build(outputs: outputs) { (signedTx, psbt, errorDescription) in
             
             if signedTx != nil {
                 
                 self.confirm(raw: signedTx!)
+                
+            } else if psbt != nil {
+                
+                self.confirmUnsigned(psbt: psbt!)
                 
             } else {
                 

--- a/FullyNoded2/FullyNoded2/View Controllers/Unlock Screen/LogInViewController.swift
+++ b/FullyNoded2/FullyNoded2/View Controllers/Unlock Screen/LogInViewController.swift
@@ -17,7 +17,7 @@ class LogInViewController: UIViewController, UITextFieldDelegate, ASAuthorizatio
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        view.backgroundColor = .darkGray
+        view.backgroundColor = .black
         let logInButton = ASAuthorizationAppleIDButton()
         logInButton.sizeToFit()
         logInButton.addTarget(self, action: #selector(handleLogInWithAppleID), for: .touchUpInside)
@@ -25,11 +25,11 @@ class LogInViewController: UIViewController, UITextFieldDelegate, ASAuthorizatio
         view.addSubview(logInButton)
         
         let description = UILabel()
-        description.font = .systemFont(ofSize: 12, weight: .regular)
+        description.font = .systemFont(ofSize: 16, weight: .light)
         description.numberOfLines = 0
+        description.frame = CGRect(x: 48, y: logInButton.frame.maxY + 5, width: self.view.frame.width - 96, height: 150)
+        description.text = "Blockchain Commons, LLC and FullyNoded 2 do not use or save your Apple ID data in anyway, it is used solely for 2FA (two-factor authentication) purposes only."
         description.sizeToFit()
-        description.frame = CGRect(x: 48, y: logInButton.frame.maxY, width: self.view.frame.width - 96, height: 70)
-        description.text = "BlockchainCommons and FullyNoded 2 do not use or save your Apple ID data in anyway, it used purely for 2 factor authentication purposes only."
         description.textAlignment = .left
         description.textColor = .white
         view.addSubview(description)

--- a/FullyNoded2/FullyNoded2/View Controllers/Wallets/Wallet Tools/ExportKeysViewController.swift
+++ b/FullyNoded2/FullyNoded2/View Controllers/Wallets/Wallet Tools/ExportKeysViewController.swift
@@ -28,7 +28,7 @@ class ExportKeysViewController: UIViewController, UITableViewDelegate, UITableVi
         
     }
     
-    override func viewWillDisappear(_ animated: Bool) {
+    override func viewDidDisappear(_ animated: Bool) {
         
         keys.removeAll()
         
@@ -294,7 +294,12 @@ class ExportKeysViewController: UIViewController, UITableViewDelegate, UITableVi
                         
                     } else {
                         
-                        self.keys[i]["address"] = (address as! String)
+                        // fixes crash caused by user pre-maturely dismissing the view as keys is emptied when the view disappears
+                        if self.keys.count > 0 {
+                            
+                            self.keys[i]["address"] = (address as! String)
+                            
+                        }
                         
                     }
                     

--- a/FullyNoded2/FullyNoded2/View Controllers/Wallets/Wallets Table/WalletsViewController.swift
+++ b/FullyNoded2/FullyNoded2/View Controllers/Wallets/Wallets Table/WalletsViewController.swift
@@ -272,17 +272,18 @@ class WalletsViewController: UIViewController, UITableViewDelegate, UITableViewD
         let getWalletInfoButton = cell.viewWithTag(12) as! UIButton
         let updatedLabel = cell.viewWithTag(13) as! UILabel
         let createdLabel = cell.viewWithTag(14) as! UILabel
-        let nodeSeedLabel = cell.viewWithTag(15) as! UILabel
+        //let nodeSeedLabel = cell.viewWithTag(15) as! UILabel
         let shareSeedButton = cell.viewWithTag(16) as! UIButton
         let rpcOnionLabel = cell.viewWithTag(19) as! UILabel
         let walletFileLabel = cell.viewWithTag(20) as! UILabel
         let seedOnDeviceView = cell.viewWithTag(21)!
-        let seedOnNodeView = cell.viewWithTag(22)!
+        //let seedOnNodeView = cell.viewWithTag(22)!
         let isActiveLabel = cell.viewWithTag(24) as! UILabel
         let stackView = cell.viewWithTag(25)!
         let nodeView = cell.viewWithTag(26)!
         let nodeLabel = cell.viewWithTag(27) as! UILabel
         let deviceXprv = cell.viewWithTag(28) as! UILabel
+        let bannerView = cell.viewWithTag(32)!
         
         if wallet.isActive {
             
@@ -290,6 +291,7 @@ class WalletsViewController: UIViewController, UITableViewDelegate, UITableViewD
             isActiveLabel.text = "Active"
             isActiveLabel.textColor = .lightGray
             cell.contentView.alpha = 1
+            bannerView.backgroundColor = #colorLiteral(red: 0, green: 0.1631944358, blue: 0.3383367703, alpha: 1)
             
         } else if !wallet.isActive {
             
@@ -297,6 +299,7 @@ class WalletsViewController: UIViewController, UITableViewDelegate, UITableViewD
             isActiveLabel.text = "Inactive"
             isActiveLabel.textColor = .darkGray
             cell.contentView.alpha = 0.6
+            bannerView.backgroundColor = #colorLiteral(red: 0.1051254794, green: 0.1292803288, blue: 0.1418488324, alpha: 1)
             
         }
         
@@ -337,7 +340,7 @@ class WalletsViewController: UIViewController, UITableViewDelegate, UITableViewD
         nodeView.layer.cornerRadius = 8
         stackView.layer.cornerRadius = 8
         seedOnDeviceView.layer.cornerRadius = 8
-        seedOnNodeView.layer.cornerRadius = 8
+        //seedOnNodeView.layer.cornerRadius = 8
         networkLabel.layer.cornerRadius = 8
         utxosButton.layer.cornerRadius = 8
         
@@ -390,7 +393,7 @@ class WalletsViewController: UIViewController, UITableViewDelegate, UITableViewD
                 let last15 = String(rpcOnion.suffix(15))
                 rpcOnionLabel.text = "\(first10)*****\(last15)"
                 nodeLabel.text = s.label
-                nodeSeedLabel.text = "1 Watch-only \(s.label)"
+                //nodeSeedLabel.text = "1 Watch-only \(s.label)"
                 
             }
             
@@ -435,6 +438,7 @@ class WalletsViewController: UIViewController, UITableViewDelegate, UITableViewD
         let deviceXprv = cell.viewWithTag(29) as! UILabel
         let nodeKeys = cell.viewWithTag(30) as! UILabel
         let offlineXprv = cell.viewWithTag(31) as! UILabel
+        let bannerView = cell.viewWithTag(33)!
         
         isActive.addTarget(self, action: #selector(makeActive(_:)), for: .valueChanged)
         isActive.restorationIdentifier = "\(indexPath.section)"
@@ -445,6 +449,7 @@ class WalletsViewController: UIViewController, UITableViewDelegate, UITableViewD
             isActiveLabel.text = "Active"
             isActiveLabel.textColor = .lightGray
             cell.contentView.alpha = 1
+            bannerView.backgroundColor = #colorLiteral(red: 0, green: 0.1631944358, blue: 0.3383367703, alpha: 1)
             
         } else if !wallet.isActive {
             
@@ -452,6 +457,7 @@ class WalletsViewController: UIViewController, UITableViewDelegate, UITableViewD
             isActiveLabel.text = "Inactive"
             isActiveLabel.textColor = .darkGray
             cell.contentView.alpha = 0.6
+            bannerView.backgroundColor = #colorLiteral(red: 0.1051254794, green: 0.1292803288, blue: 0.1418488324, alpha: 1)
             
         }
         
@@ -580,17 +586,18 @@ class WalletsViewController: UIViewController, UITableViewDelegate, UITableViewD
         let getWalletInfoButton = cell.viewWithTag(12) as! UIButton
         let updatedLabel = cell.viewWithTag(13) as! UILabel
         let createdLabel = cell.viewWithTag(14) as! UILabel
-        let nodeSeedLabel = cell.viewWithTag(15) as! UILabel
+        //let nodeSeedLabel = cell.viewWithTag(15) as! UILabel
         let exportSeedButton = cell.viewWithTag(17) as! UIButton
         let rpcOnionLabel = cell.viewWithTag(19) as! UILabel
         let walletFileLabel = cell.viewWithTag(20) as! UILabel
-        let seedOnNodeView = cell.viewWithTag(22)!
+        //let seedOnNodeView = cell.viewWithTag(22)!
         let isActiveLabel = cell.viewWithTag(24) as! UILabel
         let stackView = cell.viewWithTag(25)!
         let nodeView = cell.viewWithTag(26)!
         let nodeLabel = cell.viewWithTag(27) as! UILabel
         let keysOnNodeLabel = cell.viewWithTag(28) as! UILabel
         let typeLabel = cell.viewWithTag(29) as! UILabel
+        let bannerView = cell.viewWithTag(32)!
         
         if wallet.isActive {
             
@@ -598,6 +605,7 @@ class WalletsViewController: UIViewController, UITableViewDelegate, UITableViewD
             isActiveLabel.text = "Active"
             isActiveLabel.textColor = .lightGray
             cell.contentView.alpha = 1
+            bannerView.backgroundColor = #colorLiteral(red: 0, green: 0.1631944358, blue: 0.3383367703, alpha: 1)
             
         } else if !wallet.isActive {
             
@@ -605,6 +613,7 @@ class WalletsViewController: UIViewController, UITableViewDelegate, UITableViewD
             isActiveLabel.text = "Inactive"
             isActiveLabel.textColor = .darkGray
             cell.contentView.alpha = 0.6
+            bannerView.backgroundColor = #colorLiteral(red: 0.1051254794, green: 0.1292803288, blue: 0.1418488324, alpha: 1)
             
         }
         
@@ -644,7 +653,7 @@ class WalletsViewController: UIViewController, UITableViewDelegate, UITableViewD
         
         nodeView.layer.cornerRadius = 8
         stackView.layer.cornerRadius = 8
-        seedOnNodeView.layer.cornerRadius = 8
+        //seedOnNodeView.layer.cornerRadius = 8
         networkLabel.layer.cornerRadius = 8
         utxosButton.layer.cornerRadius = 8
         
@@ -695,22 +704,22 @@ class WalletsViewController: UIViewController, UITableViewDelegate, UITableViewD
                 
                 if descStr.isHot {
                     
-                    nodeSeedLabel.text = "\(s.label) is Hot"
+                    //nodeSeedLabel.text = "\(s.label) is Hot"
                     keysOnNodeLabel.text = "2,000 private keys on \(s.label)"
-                    cell.backgroundColor = #colorLiteral(red: 0.3412515863, green: 0.07937019594, blue: 0.06658586931, alpha: 1)
-                    seedOnNodeView.backgroundColor = #colorLiteral(red: 0.3983185279, green: 0.09264314329, blue: 0.07772091475, alpha: 1)
-                    nodeView.backgroundColor = #colorLiteral(red: 0.3983185279, green: 0.09264314329, blue: 0.07772091475, alpha: 1)
-                    stackView.backgroundColor = #colorLiteral(red: 0.3983185279, green: 0.09264314329, blue: 0.07772091475, alpha: 1)
-                    balanceLabel.textColor = .lightGray
+//                    cell.backgroundColor = #colorLiteral(red: 0.3412515863, green: 0.07937019594, blue: 0.06658586931, alpha: 1)
+//                    seedOnNodeView.backgroundColor = #colorLiteral(red: 0.3983185279, green: 0.09264314329, blue: 0.07772091475, alpha: 1)
+//                    nodeView.backgroundColor = #colorLiteral(red: 0.3983185279, green: 0.09264314329, blue: 0.07772091475, alpha: 1)
+//                    stackView.backgroundColor = #colorLiteral(red: 0.3983185279, green: 0.09264314329, blue: 0.07772091475, alpha: 1)
+//                    balanceLabel.textColor = .lightGray
                     
                 } else {
                     
-                    nodeSeedLabel.text = "\(s.label) is Cold"
+                    //nodeSeedLabel.text = "\(s.label) is Cold"
                     keysOnNodeLabel.text = "2,000 public keys on \(s.label)"
-                    cell.backgroundColor = #colorLiteral(red: 0, green: 0.1354581723, blue: 0.2808335977, alpha: 1)
-                    seedOnNodeView.backgroundColor = #colorLiteral(red: 0, green: 0.1579723669, blue: 0.3275103109, alpha: 1)
-                    nodeView.backgroundColor = #colorLiteral(red: 0, green: 0.1579723669, blue: 0.3275103109, alpha: 1)
-                    stackView.backgroundColor = #colorLiteral(red: 0, green: 0.1579723669, blue: 0.3275103109, alpha: 1)
+//                    cell.backgroundColor = #colorLiteral(red: 0, green: 0.1354581723, blue: 0.2808335977, alpha: 1)
+//                    seedOnNodeView.backgroundColor = #colorLiteral(red: 0, green: 0.1579723669, blue: 0.3275103109, alpha: 1)
+//                    nodeView.backgroundColor = #colorLiteral(red: 0, green: 0.1579723669, blue: 0.3275103109, alpha: 1)
+//                    stackView.backgroundColor = #colorLiteral(red: 0, green: 0.1579723669, blue: 0.3275103109, alpha: 1)
                     
                 }
                 
@@ -1092,15 +1101,15 @@ class WalletsViewController: UIViewController, UITableViewDelegate, UITableViewD
                 
             case "DEFAULT":
                 
-                return 370
+                return 377
                 
             case "MULTI":
                 
-                return 403
+                return 435
                 
             case "CUSTOM":
                 
-                return 310
+                return 294
                 
             default:
                 


### PR DESCRIPTION
- add support for importing BIP44/84/49 descriptors 
- try new method of reconnecting tor which should prevent any crashes
- WIP ability to scan an unsigned multi-sig PSBT and sign it 
- UI update to WalletViewController cells 
- prevent a bug which caused a crash when navigating away from key export 
- add authkeys if they do not exist when exporting them 
- add close button to authentication view 
- no longer add a redundant background view when presenting RawDisplayer() 
- update “Sign in with Apple” description 
- fix error view being cut off and text overlapping image
- add ability to create unsigned transactions with Single Signature wallets
- use Blockchair V3 onion API for fetching bitcoin price data