### PR TITLE
UX Improvements and bug fixes.

### DIFF
--- a/XCode/FullyNoded2.xcodeproj/project.pbxproj
+++ b/XCode/FullyNoded2.xcodeproj/project.pbxproj
@@ -1303,7 +1303,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = FullyNoded2/FullyNoded2.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 0.1.39;
+				CURRENT_PROJECT_VERSION = 0.1.40;
 				DEVELOPMENT_TEAM = YZHG975W3A;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1317,7 +1317,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.39;
+				MARKETING_VERSION = 0.1.40;
 				PRODUCT_BUNDLE_IDENTIFIER = com.blockchaincommons.standupios;
 				PRODUCT_NAME = "FullyNoded 2";
 				SUPPORTS_MACCATALYST = NO;
@@ -1335,7 +1335,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = FullyNoded2/FullyNoded2.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 0.1.39;
+				CURRENT_PROJECT_VERSION = 0.1.40;
 				DEVELOPMENT_TEAM = YZHG975W3A;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1349,7 +1349,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.39;
+				MARKETING_VERSION = 0.1.40;
 				PRODUCT_BUNDLE_IDENTIFIER = com.blockchaincommons.standupios;
 				PRODUCT_NAME = "FullyNoded 2";
 				SUPPORTS_MACCATALYST = NO;

--- a/XCode/FullyNoded2.xcodeproj/project.pbxproj
+++ b/XCode/FullyNoded2.xcodeproj/project.pbxproj
@@ -1303,7 +1303,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = FullyNoded2/FullyNoded2.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 0.1.40;
+				CURRENT_PROJECT_VERSION = 0.1.41;
 				DEVELOPMENT_TEAM = YZHG975W3A;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1317,7 +1317,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.40;
+				MARKETING_VERSION = 0.1.41;
 				PRODUCT_BUNDLE_IDENTIFIER = com.blockchaincommons.standupios;
 				PRODUCT_NAME = "FullyNoded 2";
 				SUPPORTS_MACCATALYST = NO;
@@ -1335,7 +1335,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = FullyNoded2/FullyNoded2.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 0.1.40;
+				CURRENT_PROJECT_VERSION = 0.1.41;
 				DEVELOPMENT_TEAM = YZHG975W3A;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1349,7 +1349,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.40;
+				MARKETING_VERSION = 0.1.41;
 				PRODUCT_BUNDLE_IDENTIFIER = com.blockchaincommons.standupios;
 				PRODUCT_NAME = "FullyNoded 2";
 				SUPPORTS_MACCATALYST = NO;

--- a/XCode/FullyNoded2/Helpers/QuickConnect.swift
+++ b/XCode/FullyNoded2/Helpers/QuickConnect.swift
@@ -161,7 +161,9 @@ class QuickConnect {
                             }
                             
                             if i + 1 == nodes!.count {
-                                NotificationCenter.default.post(name: .nodeSwitched, object: nil, userInfo: nil)
+                                DispatchQueue.main.async {
+                                    NotificationCenter.default.post(name: .nodeSwitched, object: nil, userInfo: nil)
+                                }
                             }
                         }
                         

--- a/XCode/FullyNoded2/Helpers/QuickConnect.swift
+++ b/XCode/FullyNoded2/Helpers/QuickConnect.swift
@@ -152,7 +152,7 @@ class QuickConnect {
                     
                     if nodes!.count > 0 {
                         
-                        for node in nodes! {
+                        for (i, node) in nodes!.enumerated() {
                             
                             if node ["id"] as! UUID != newNodeID {
                                 
@@ -160,6 +160,9 @@ class QuickConnect {
                                 
                             }
                             
+                            if i + 1 == nodes!.count {
+                                NotificationCenter.default.post(name: .nodeSwitched, object: nil, userInfo: nil)
+                            }
                         }
                         
                     }

--- a/XCode/FullyNoded2/Main.storyboard
+++ b/XCode/FullyNoded2/Main.storyboard
@@ -5235,12 +5235,6 @@ At a minimum we recommend writing these words down on water proof paper with a p
                                                 <view clipsSubviews="YES" tag="23" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pII-Us-N4E">
                                                     <rect key="frame" x="15" y="323" width="315" height="75"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HnI-vK-gV2">
-                                                            <rect key="frame" x="306" y="18.5" width="0.0" height="0.0"/>
-                                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                            <nil key="textColor"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="capslock" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="fM0-H2-WD1">
                                                             <rect key="frame" x="290" y="8.5" width="16" height="21"/>
                                                             <color key="tintColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -5298,7 +5292,6 @@ At a minimum we recommend writing these words down on water proof paper with a p
                                                         <constraint firstItem="fM0-H2-WD1" firstAttribute="top" secondItem="pII-Us-N4E" secondAttribute="top" constant="8" id="4Oz-RU-m9g"/>
                                                         <constraint firstItem="MXd-Cr-eMh" firstAttribute="top" secondItem="kRm-D3-fc5" secondAttribute="bottom" constant="8" id="5oI-AY-dRD"/>
                                                         <constraint firstItem="Z4d-ga-qGm" firstAttribute="top" secondItem="MXd-Cr-eMh" secondAttribute="bottom" constant="4" id="CKl-DL-UXz"/>
-                                                        <constraint firstAttribute="trailing" secondItem="HnI-vK-gV2" secondAttribute="trailing" constant="9" id="JOi-qq-dLo"/>
                                                         <constraint firstItem="Upj-Sb-mG8" firstAttribute="centerY" secondItem="MXd-Cr-eMh" secondAttribute="centerY" id="N5a-Jh-EwX"/>
                                                         <constraint firstAttribute="height" constant="75" id="NLG-CP-m1S"/>
                                                         <constraint firstItem="kRm-D3-fc5" firstAttribute="leading" secondItem="pII-Us-N4E" secondAttribute="leading" constant="8" id="NNq-06-t5Q"/>
@@ -5855,7 +5848,7 @@ At a minimum we recommend writing these words down on water proof paper with a p
                                                             <color key="textColor" systemColor="systemGreenColor" red="0.20392156859999999" green="0.78039215689999997" blue="0.34901960780000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" tag="11" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="utxo label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="LPG-PJ-EKW">
+                                                        <label opaque="NO" userInteractionEnabled="NO" tag="11" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="utxo label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="LPG-PJ-EKW">
                                                             <rect key="frame" x="0.0" y="34.5" width="55" height="14.5"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="14.5" id="d5C-wa-9vP"/>
@@ -5941,7 +5934,7 @@ At a minimum we recommend writing these words down on water proof paper with a p
                                                             <color key="textColor" systemColor="systemGreenColor" red="0.20392156859999999" green="0.78039215689999997" blue="0.34901960780000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" tag="11" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="utxo label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jS0-qK-Cda">
+                                                        <label opaque="NO" userInteractionEnabled="NO" tag="11" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="utxo label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="jS0-qK-Cda">
                                                             <rect key="frame" x="0.0" y="34.5" width="55" height="14.5"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="14.5" id="ExF-1G-Qeb"/>

--- a/XCode/FullyNoded2/Main.storyboard
+++ b/XCode/FullyNoded2/Main.storyboard
@@ -3734,11 +3734,12 @@ At a minimum we recommend writing these words down on water proof paper with a p
                         <outlet property="walletName" destination="xGr-Cf-ptF" id="Bq1-1o-mM1"/>
                         <outlet property="walletNetwork" destination="2bf-wN-KDI" id="7QL-HG-uUX"/>
                         <outlet property="walletType" destination="211-Vb-3Oy" id="eG2-eJ-x7q"/>
+                        <segue destination="shH-Cs-byi" kind="show" identifier="addLabelToRecoveredAccount" id="2kH-rb-1zK"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="X0Q-Sq-lne" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-2767" y="1475"/>
+            <point key="canvasLocation" x="-2657" y="1521"/>
         </scene>
         <!--Locked UTXO Info-->
         <scene sceneID="MG3-9N-gz0">
@@ -6113,7 +6114,7 @@ At a minimum we recommend writing these words down on water proof paper with a p
         <segue reference="igz-Ga-xca"/>
         <segue reference="NHy-Xu-LiC"/>
         <segue reference="c5y-jb-z8M"/>
-        <segue reference="MTV-lr-E4R"/>
+        <segue reference="2kH-rb-1zK"/>
         <segue reference="cZz-Rg-m7M"/>
         <segue reference="zTj-XW-s3J"/>
     </inferredMetricsTieBreakers>

--- a/XCode/FullyNoded2/Miscellaneous/Utilities.swift
+++ b/XCode/FullyNoded2/Miscellaneous/Utilities.swift
@@ -93,6 +93,7 @@ extension Notification.Name {
     public static let seedDeleted = Notification.Name(rawValue: "seedDeleted")
     public static let transactionSent = Notification.Name(rawValue: "transactionSent")
     public static let nodeSwitched = Notification.Name(rawValue: "nodeSwitched")
+    public static let didUpdateLabel = Notification.Name(rawValue: "didUpdateLabel")
 }
 
 public extension Int {

--- a/XCode/FullyNoded2/Miscellaneous/Utilities.swift
+++ b/XCode/FullyNoded2/Miscellaneous/Utilities.swift
@@ -86,6 +86,13 @@ extension Notification.Name {
     public static let didCompleteOnboarding = Notification.Name(rawValue: "didCompleteOnboarding")
     public static let didSweep = Notification.Name(rawValue: "didSweep")
     public static let didSwitchAccounts = Notification.Name(rawValue: "didSwitchAccounts")
+    public static let didCreateAccount = Notification.Name(rawValue: "didCreateAccount")
+    public static let didRescanAccount = Notification.Name(rawValue: "didRescanAccount")
+    public static let didAbortRescan = Notification.Name(rawValue: "didAbortRescan")
+    public static let seedAdded = Notification.Name(rawValue: "seedAdded")
+    public static let seedDeleted = Notification.Name(rawValue: "seedDeleted")
+    public static let transactionSent = Notification.Name(rawValue: "transactionSent")
+    public static let nodeSwitched = Notification.Name(rawValue: "nodeSwitched")
 }
 
 public extension Int {

--- a/XCode/FullyNoded2/Node Logic/NodeLogic.swift
+++ b/XCode/FullyNoded2/Node Logic/NodeLogic.swift
@@ -67,7 +67,7 @@ class NodeLogic {
                 vc.parseUtxos(wallet: wallet, utxos: utxos, completion: completion)
                 
             } else {
-                completion((false, nil, "returned object is nil"))
+                completion((true, nil, nil))
                 
             }
         }
@@ -79,7 +79,7 @@ class NodeLogic {
                 vc.parseUtxos(wallet: wallet, utxos: utxos, completion: completion)
                 
             } else {
-                completion((false, nil, "returned object is nil"))
+                completion((true, nil, nil))
                 
             }
         }

--- a/XCode/FullyNoded2/View Controllers/Home Screen/SeedsViewController.swift
+++ b/XCode/FullyNoded2/View Controllers/Home Screen/SeedsViewController.swift
@@ -120,6 +120,7 @@ class SeedsViewController: UIViewController, UITableViewDelegate, UITableViewDat
                 DispatchQueue.main.async { [unowned vc = self] in
                     vc.seedsArray.remove(at: vc.indPath.row)
                     vc.seedsTable.deleteRows(at: [vc.indPath], with: .fade)
+                    NotificationCenter.default.post(name: .seedDeleted, object: nil, userInfo: nil)
                     
                 }
                 

--- a/XCode/FullyNoded2/View Controllers/Home Screen/Settings/NodeManagerViewController.swift
+++ b/XCode/FullyNoded2/View Controllers/Home Screen/Settings/NodeManagerViewController.swift
@@ -409,7 +409,9 @@ class NodeManagerViewController: UIViewController, UITableViewDelegate, UITableV
                         
                     }
                     if i + 1 == wallets!.count {
-                        NotificationCenter.default.post(name: .nodeSwitched, object: nil, userInfo: nil)
+                        DispatchQueue.main.async {
+                            NotificationCenter.default.post(name: .nodeSwitched, object: nil, userInfo: nil)
+                        }
                     }
                 }
                 

--- a/XCode/FullyNoded2/View Controllers/Home Screen/Settings/NodeManagerViewController.swift
+++ b/XCode/FullyNoded2/View Controllers/Home Screen/Settings/NodeManagerViewController.swift
@@ -293,37 +293,30 @@ class NodeManagerViewController: UIViewController, UITableViewDelegate, UITableV
     }
     
     @objc func alternate(_ sender: UISwitch) {
-        print("alternate")
-        
-        let restId = sender.restorationIdentifier!
-        let section = Int(restId)!
-        let node = nodes[section]
-        let idToActivate = NodeStruct.init(dictionary: node).id
-        
-       if sender.isOn {
-            
-            //turning on
-            makeActive(nodeToActivate: idToActivate)
-            
-        } else {
-            
-            self.table.reloadSections([section], with: .fade)
-            
-            showAlert(vc: self, title: "Alert", message: "You must always have one active node, if you would like to use a different node simply switch it on and the other nodes will be switched off automatically.")
-            
+        if sender.restorationIdentifier != nil {
+            if let section = Int(sender.restorationIdentifier!) {
+                let node = nodes[section]
+                let idToActivate = NodeStruct.init(dictionary: node).id
+                if sender.isOn {
+                    //turning on
+                    makeActive(nodeToActivate: idToActivate)
+                } else {
+                    table.reloadSections([section], with: .fade)
+                    showAlert(vc: self, title: "Alert", message: "You must always have one active node, if you would like to use a different node simply switch it on and the other nodes will be switched off automatically.")
+                }
+            }
         }
-        
     }
     
     func makeActive(nodeToActivate: UUID) {
         
-        CoreDataService.retrieveEntity(entityName: .nodes) { [unowned vc = self] (nodess, errorDescription) in
+        CoreDataService.retrieveEntity(entityName: .nodes) { [unowned vc = self] (nodes, errorDescription) in
             
             if errorDescription == nil {
                 
-                if nodess!.count > 0 {
+                if nodes!.count > 0 {
                     
-                    for node in nodess! {
+                    for node in nodes! {
                         
                         let str = NodeStruct.init(dictionary: node)
                         
@@ -360,53 +353,29 @@ class NodeManagerViewController: UIViewController, UITableViewDelegate, UITableV
     }
     
     func deactivateOtherNodes(nodeToActivate: UUID) {
-        print("deactivateOtherNodes")
-        
-        CoreDataService.retrieveEntity(entityName: .nodes) { [unowned vc = self] (nodess, errorDescription) in
-            
+        CoreDataService.retrieveEntity(entityName: .nodes) { [unowned vc = self] (nodes, errorDescription) in
             if errorDescription == nil {
-                
-                if nodess!.count > 0 {
-                    
-                    for (i, node) in nodess!.enumerated() {
-                        
+                if nodes!.count > 0 {
+                    for (i, node) in nodes!.enumerated() {
                         let str = NodeStruct.init(dictionary: node)
-                        
                         if str.id != nodeToActivate {
-                            
                             CoreDataService.updateEntity(id: str.id, keyToUpdate: "isActive", newValue: false, entityName: .nodes) { (success1, errorDescription1) in
-                                
-                                if success1 {
-                                    
-                                    if i + 1 == nodess!.count {
-                                        
-                                        vc.load()
-                                        
-                                    }
-                                    
-                                } else {
-                                    
+                                if !success1 {
                                     displayAlert(viewController: vc, isError: true, message: errorDescription1 ?? "error updating")
-                                    
                                 }
-                                
                             }
-                            
                         }
-                        
+                        if i + 1 == nodes!.count {
+                            vc.load()
+                            vc.deactiveateWallets(nodeToActivateId: nodeToActivate)
+                        }
                     }
-                    
                 }
-                
             }
-            
         }
-        
-        deactiveateWallets()
-        
     }
     
-    private func deactiveateWallets() {
+    private func deactiveateWallets(nodeToActivateId: UUID) {
         
         CoreDataService.retrieveEntity(entityName: .wallets) { (wallets, errorDescription) in
             
@@ -414,10 +383,10 @@ class NodeManagerViewController: UIViewController, UITableViewDelegate, UITableV
                 
                 for wallet in wallets! {
                     
-                    if wallet["id"] != nil && wallet["isArchived"] != nil {
+                    if wallet["id"] != nil && wallet["isArchived"] != nil && wallet["nodeId"] != nil {
                         let w = WalletStruct(dictionary: wallet)
                         
-                        if !w.isArchived && w.isActive {
+                        if !w.isArchived && w.isActive && w.nodeId! != nodeToActivateId {
                             
                             CoreDataService.updateEntity(id: w.id!, keyToUpdate: "isActive", newValue: false, entityName: .wallets) { (success, errorDescription) in
                                 

--- a/XCode/FullyNoded2/View Controllers/Home Screen/Settings/NodeManagerViewController.swift
+++ b/XCode/FullyNoded2/View Controllers/Home Screen/Settings/NodeManagerViewController.swift
@@ -116,6 +116,7 @@ class NodeManagerViewController: UIViewController, UITableViewDelegate, UITableV
                                     
                                     vc.nodes.remove(at: indexPath.section)
                                     tableView.deleteSections(IndexSet.init(arrayLiteral: indexPath.section), with: .fade)
+                                    NotificationCenter.default.post(name: .nodeSwitched, object: nil, userInfo: nil)
                                     
                                 }
                                 
@@ -381,7 +382,7 @@ class NodeManagerViewController: UIViewController, UITableViewDelegate, UITableV
             
             if wallets != nil {
                 
-                for wallet in wallets! {
+                for (i, wallet) in wallets!.enumerated() {
                     
                     if wallet["id"] != nil && wallet["isArchived"] != nil && wallet["nodeId"] != nil {
                         let w = WalletStruct(dictionary: wallet)
@@ -407,7 +408,9 @@ class NodeManagerViewController: UIViewController, UITableViewDelegate, UITableV
                         }
                         
                     }
-                    
+                    if i + 1 == wallets!.count {
+                        NotificationCenter.default.post(name: .nodeSwitched, object: nil, userInfo: nil)
+                    }
                 }
                 
             }

--- a/XCode/FullyNoded2/View Controllers/Outgoing/ConfirmViewController.swift
+++ b/XCode/FullyNoded2/View Controllers/Outgoing/ConfirmViewController.swift
@@ -252,9 +252,13 @@ class ConfirmViewController: UIViewController, UINavigationControllerDelegate, U
                                          message: "Transaction sent ✓")
                             
                             if vc.sweeping {
-                                
-                                NotificationCenter.default.post(name: .didSweep, object: nil, userInfo: nil)
-                                
+                                DispatchQueue.main.async {
+                                    NotificationCenter.default.post(name: .didSweep, object: nil, userInfo: nil)
+                                }
+                            } else {
+                                DispatchQueue.main.async {
+                                    NotificationCenter.default.post(name: .transactionSent, object: nil, userInfo: nil)
+                                }
                             }
                             
                         }
@@ -364,15 +368,11 @@ class ConfirmViewController: UIViewController, UINavigationControllerDelegate, U
     }
     
     func getInputInfo(index: Int) {
-        
         let dict = inputArray[index]
         let txid = dict["txid"] as! String
         let vout = dict["vout"] as! Int
-        
-        parsePrevTx(method: .getrawtransaction,
-                    param: "\"\(txid)\"",
-                    vout: vout)
-        
+        //parsePrevTx(method: .getrawtransaction, param: "\"\(txid)\"", vout: vout)
+        parsePrevTx(method: .gettransaction, param: "\"\(txid)\", true", vout: vout)
     }
     
     func parseInputs(inputs: NSArray, completion: @escaping () -> Void) {
@@ -562,7 +562,7 @@ class ConfirmViewController: UIViewController, UINavigationControllerDelegate, U
                 } else {
                     
                     vc.creatingView.removeConnectingView()
-                    displayAlert(viewController: vc, isError: true, message: "Error parsing inputs")
+                    displayAlert(viewController: vc, isError: true, message: "Error decoding raw transaction")
                     
                 }
                 
@@ -572,13 +572,12 @@ class ConfirmViewController: UIViewController, UINavigationControllerDelegate, U
         
         func getRawTx(walletName: String) {
             
-            Reducer.makeCommand(walletName: walletName, command: .getrawtransaction, param: param) { [unowned vc = self] (object, errorDescription) in
+            Reducer.makeCommand(walletName: walletName, command: .gettransaction, param: param) { [unowned vc = self] (object, errorDescription) in
                 
-                if let rawTransaction = object as? String {
+                //if let rawTransaction = object as? String {
+                if let dict = object as? NSDictionary, let hex = dict["hex"] as? String {
                     
-                    vc.parsePrevTx(method: .decoderawtransaction,
-                                param: "\"\(rawTransaction)\"",
-                                vout: vout)
+                    vc.parsePrevTx(method: .decoderawtransaction, param: "\"\(hex)\"", vout: vout)
                     
                 } else {
                     
@@ -603,7 +602,7 @@ class ConfirmViewController: UIViewController, UINavigationControllerDelegate, U
                         
                         decodeRaw(walletName: wallet!.name!)
                         
-                    case .getrawtransaction:
+                    case .gettransaction:
                         
                         getRawTx(walletName: wallet!.name!)
                         
@@ -987,9 +986,13 @@ class ConfirmViewController: UIViewController, UINavigationControllerDelegate, U
                                  message: "Transaction sent ✓")
                     
                     if vc.sweeping {
-                        
-                        NotificationCenter.default.post(name: .didSweep, object: nil, userInfo: nil)
-                        
+                        DispatchQueue.main.async {
+                            NotificationCenter.default.post(name: .didSweep, object: nil, userInfo: nil)
+                        }
+                    } else {
+                        DispatchQueue.main.async {
+                            NotificationCenter.default.post(name: .transactionSent, object: nil, userInfo: nil)
+                        }
                     }
                     
                 }

--- a/XCode/FullyNoded2/View Controllers/Outgoing/Raw Tx/CreateRawTxViewController.swift
+++ b/XCode/FullyNoded2/View Controllers/Outgoing/Raw Tx/CreateRawTxViewController.swift
@@ -211,22 +211,20 @@ class CreateRawTxViewController: UIViewController, UITextFieldDelegate, UITableV
                                         let str = LockedUtxoStruct.init(dictionary: lockedUtxo)
                                         if vc.isChange(str.desc) && txid == str.txid && vout == str.vout {
                                             utxosToUnlock.append(dict)
-                                            if i + 1 == utxos.count && x + 1 == lockedUtxos!.count {
-                                                CoinControl.unlockUtxos(utxos: utxosToUnlock) { success in
-                                                    completion(success)
-                                                }
+                                        }
+                                        if i + 1 == utxos.count && x + 1 == lockedUtxos!.count {
+                                            CoinControl.unlockUtxos(utxos: utxosToUnlock) { success in
+                                                completion(success)
                                             }
                                         }
                                     }
                                 } else {
-                                    CoinControl.unlockUtxos(utxos: utxosToUnlock) { success in
-                                        completion(success)
-                                    }
+                                    showAlert(vc: vc, title: "Error", message: "We can not unlock change utxo's that were locked outside of FN2.")
+                                    completion(false)
                                 }
                             } else {
-                                CoinControl.unlockUtxos(utxos: utxosToUnlock) { success in
-                                    completion(success)
-                                }
+                                showAlert(vc: vc, title: "Error", message: "We can not unlock change utxo's that were locked outside of FN2.")
+                                completion(false)
                             }
                         }
                     }
@@ -249,7 +247,7 @@ class CreateRawTxViewController: UIViewController, UITextFieldDelegate, UITableV
                         let dict = utxo as! [String:Any]
                         let txid = dict["txid"] as! String
                         let vout = dict["vout"] as! Int
-                        CoreDataService.retrieveEntity(entityName: .lockedUtxos) { (lockedUtxos, errorDescription) in
+                        CoreDataService.retrieveEntity(entityName: .lockedUtxos) { [unowned vc = self] (lockedUtxos, errorDescription) in
                             if lockedUtxos != nil {
                                 if lockedUtxos!.count > 0 {
                                     for (x, lockedUtxo) in lockedUtxos!.enumerated() {
@@ -264,14 +262,12 @@ class CreateRawTxViewController: UIViewController, UITextFieldDelegate, UITableV
                                         }
                                     }
                                 } else {
-                                    CoinControl.unlockUtxos(utxos: utxosToUnlock) { success in
-                                        completion(success)
-                                    }
+                                    showAlert(vc: vc, title: "Error", message: "We can not unlock dust utxo's that were locked outside of FN2.")
+                                    completion(false)
                                 }
                             } else {
-                                CoinControl.unlockUtxos(utxos: utxosToUnlock) { success in
-                                    completion(success)
-                                }
+                                showAlert(vc: vc, title: "Error", message: "We can not unlock dust utxo's that were locked outside of FN2.")
+                                completion(false)
                             }
                         }
                     }

--- a/XCode/FullyNoded2/View Controllers/Wallets/Seed/SeedViewController.swift
+++ b/XCode/FullyNoded2/View Controllers/Wallets/Seed/SeedViewController.swift
@@ -274,6 +274,9 @@ class SeedViewController: UIViewController, UITableViewDelegate, UITableViewData
                                     vc.loadData()
                                     if succeeded {
                                         displayAlert(viewController: vc, isError: false, message: "Device's seed deleted")
+                                        DispatchQueue.main.async {
+                                            NotificationCenter.default.post(name: .seedDeleted, object: nil, userInfo: nil)
+                                        }
                                     } else {
                                         showAlert(vc: vc, title: "Error", message: "There was an error deleting one of your device's seeds.")
                                     }

--- a/XCode/FullyNoded2/View Controllers/Wallets/Wallet Recovery/ConfirmRecoveryViewController.swift
+++ b/XCode/FullyNoded2/View Controllers/Wallets/Wallet Recovery/ConfirmRecoveryViewController.swift
@@ -151,6 +151,7 @@ class ConfirmRecoveryViewController: UIViewController, UITableViewDelegate, UITa
         }
         
         func walletSuccessfullyCreated() {
+            NotificationCenter.default.post(name: .didCreateAccount, object: nil, userInfo: nil)
             DispatchQueue.main.async { [unowned vc = self] in
                 let alert = UIAlertController(title: "Account \(importedOrRecovered)!", message: "Your \(importedOrRecovered) account will now show up in \"Accounts\", a blockchain rescan has been initiated", preferredStyle: .actionSheet)
                 alert.addAction(UIAlertAction(title: "Done", style: .cancel, handler: { action in

--- a/XCode/FullyNoded2/View Controllers/Wallets/Wallet Recovery/WordRecoveryViewController.swift
+++ b/XCode/FullyNoded2/View Controllers/Wallets/Wallet Recovery/WordRecoveryViewController.swift
@@ -370,6 +370,7 @@ class WordRecoveryViewController: UIViewController, UITextFieldDelegate, UINavig
                                 vc.updatePlaceHolder(wordNumber: 1)
                                 
                             }
+                            NotificationCenter.default.post(name: .seedAdded, object: nil, userInfo: nil)
                             
                             showAlert(vc: vc, title: "Seed saved!", message: "You may go back or add another seed.")
                             

--- a/XCode/FullyNoded2/View Controllers/Wallets/Wallet Recovery/WordRecoveryViewController.swift
+++ b/XCode/FullyNoded2/View Controllers/Wallets/Wallet Recovery/WordRecoveryViewController.swift
@@ -368,9 +368,8 @@ class WordRecoveryViewController: UIViewController, UITextFieldDelegate, UINavig
                                 vc.justWords.removeAll()
                                 vc.addedWords.removeAll()
                                 vc.updatePlaceHolder(wordNumber: 1)
-                                
+                                NotificationCenter.default.post(name: .seedAdded, object: nil, userInfo: nil)
                             }
-                            NotificationCenter.default.post(name: .seedAdded, object: nil, userInfo: nil)
                             
                             showAlert(vc: vc, title: "Seed saved!", message: "You may go back or add another seed.")
                             

--- a/XCode/FullyNoded2/View Controllers/Wallets/Wallet Tools/RefillMultisigViewController.swift
+++ b/XCode/FullyNoded2/View Controllers/Wallets/Wallet Tools/RefillMultisigViewController.swift
@@ -389,8 +389,9 @@ class RefillMultisigViewController: UIViewController, UITextFieldDelegate {
                             }
                             
                             showAlert(vc: vc, title: "Success!", message: "Signer added, the device will now be able to sign for this wallet.")
-                            
-                            NotificationCenter.default.post(name: .seedAdded, object: nil, userInfo: nil)
+                            DispatchQueue.main.async {
+                                NotificationCenter.default.post(name: .seedAdded, object: nil, userInfo: nil)
+                            }
                             
                         } else {
                             

--- a/XCode/FullyNoded2/View Controllers/Wallets/Wallet Tools/RefillMultisigViewController.swift
+++ b/XCode/FullyNoded2/View Controllers/Wallets/Wallet Tools/RefillMultisigViewController.swift
@@ -390,6 +390,8 @@ class RefillMultisigViewController: UIViewController, UITextFieldDelegate {
                             
                             showAlert(vc: vc, title: "Success!", message: "Signer added, the device will now be able to sign for this wallet.")
                             
+                            NotificationCenter.default.post(name: .seedAdded, object: nil, userInfo: nil)
+                            
                         } else {
                             
                             showAlert(vc: vc, title: "Error", message: "We had an error saving your seed: \(errorDescription ?? "unknown error")")

--- a/XCode/FullyNoded2/View Controllers/Wallets/Wallet Tools/WalletToolsViewController.swift
+++ b/XCode/FullyNoded2/View Controllers/Wallets/Wallet Tools/WalletToolsViewController.swift
@@ -229,6 +229,7 @@ class WalletToolsViewController: UIViewController {
                             vc.creatingView.removeConnectingView()
                             let progress = (scanning["progress"] as! Double)
                             showAlert(vc: vc, title: "Rescanning", message: "Wallet is rescanning with current progress: \((progress * 100).rounded())%")
+                            NotificationCenter.default.post(name: .didRescanAccount, object: nil, userInfo: nil)
                             
                         }
                         
@@ -236,6 +237,7 @@ class WalletToolsViewController: UIViewController {
                         
                         vc.creatingView.removeConnectingView()
                         showAlert(vc: vc, title: "Scan Complete", message: "The wallet is not currently scanning.")
+                        NotificationCenter.default.post(name: .didRescanAccount, object: nil, userInfo: nil)
                         
                     } else {
                         
@@ -280,6 +282,7 @@ class WalletToolsViewController: UIViewController {
                             vc.creatingView.removeConnectingView()
                             let progress = (scanning["progress"] as! Double)
                             showAlert(vc: vc, title: "Rescanning", message: "Wallet is rescanning with current progress: \((progress * 100).rounded())%")
+                            NotificationCenter.default.post(name: .didRescanAccount, object: nil, userInfo: nil)
                             
                         }
                         
@@ -287,11 +290,13 @@ class WalletToolsViewController: UIViewController {
                         
                         vc.creatingView.removeConnectingView()
                         showAlert(vc: vc, title: "Scan Complete", message: "The wallet is not currently scanning.")
+                        NotificationCenter.default.post(name: .didRescanAccount, object: nil, userInfo: nil)
                         
                     } else {
                         
                         vc.creatingView.removeConnectingView()
                         showAlert(vc: vc, title: "Scan Complete", message: "Unable to determine if wallet is rescanning.")
+                        NotificationCenter.default.post(name: .didRescanAccount, object: nil, userInfo: nil)
                         
                     }
                     
@@ -323,6 +328,7 @@ class WalletToolsViewController: UIViewController {
                         vc.creatingView.removeConnectingView()
                         let progress = (scanning["progress"] as! Double)
                         showAlert(vc: vc, title: "Rescanning", message: "Wallet is rescanning with current progress: \((progress * 100).rounded())%")
+                        NotificationCenter.default.post(name: .didRescanAccount, object: nil, userInfo: nil)
                         
                     }
                     
@@ -330,11 +336,13 @@ class WalletToolsViewController: UIViewController {
                     
                     vc.creatingView.removeConnectingView()
                     showAlert(vc: vc, title: "Scan Complete", message: "Wallet not rescanning.")
+                    NotificationCenter.default.post(name: .didRescanAccount, object: nil, userInfo: nil)
                     
                 } else {
                     
                     vc.creatingView.removeConnectingView()
                     showAlert(vc: vc, title: "Error", message: "Unable to determine if wallet is rescanning.")
+                    NotificationCenter.default.post(name: .didRescanAccount, object: nil, userInfo: nil)
                     
                 }
                 
@@ -350,18 +358,15 @@ class WalletToolsViewController: UIViewController {
     }
     
     private func abortRescan() {
-        
-        self.creatingView.addConnectingView(vc: self, description: "aborting rescan")
-        
+        creatingView.addConnectingView(vc: self, description: "aborting rescan")
         Reducer.makeCommand(walletName: self.wallet.name!, command: .abortrescan, param: "") { [unowned vc = self] (object, errorDesc) in
             
             if object != nil {
-                
                 vc.creatingView.removeConnectingView()
                 showAlert(vc: vc, title: "Rescan aborted", message: "")
+                NotificationCenter.default.post(name: .didAbortRescan, object: nil, userInfo: nil)
                 
             } else {
-                
                 vc.creatingView.removeConnectingView()
                 showAlert(vc: vc, title: "Error", message: errorDesc ?? "unknown error")
                 
@@ -372,7 +377,6 @@ class WalletToolsViewController: UIViewController {
     }
     
     // MARK: - Info Button's
-    
     @IBAction func rescanInfo(_ sender: Any) {
         showInfo(title: "Rescan Info", message: TextBlurbs.rescanInfoText())
     }

--- a/XCode/FullyNoded2/View Controllers/Wallets/Wallet Tools/WalletToolsViewController.swift
+++ b/XCode/FullyNoded2/View Controllers/Wallets/Wallet Tools/WalletToolsViewController.swift
@@ -210,46 +210,60 @@ class WalletToolsViewController: UIViewController {
     private func rescanFromBirthdate() {
         
         self.creatingView.addConnectingView(vc: self, description: "initiating rescan")
-        Reducer.makeCommand(walletName: self.wallet.name!, command: .rescanblockchain, param: "\(self.wallet.blockheight)") { [unowned vc = self] _ in
+        Reducer.makeCommand(walletName: self.wallet.name!, command: .rescanblockchain, param: "\(self.wallet.blockheight)") { [unowned vc = self] (object, errorDesc) in
             
-            DispatchQueue.main.async {
-                
-                vc.creatingView.label.text = "confirming rescan status"
-                
-            }
-            
-            Reducer.makeCommand(walletName: vc.wallet.name!, command: .getwalletinfo, param: "") { (object, errorDesc) in
-                
-                if let result = object as? NSDictionary {
+            if errorDesc != nil {
+                vc.creatingView.removeConnectingView()
+                if errorDesc!.contains("Wallet is currently rescanning") {
+                    DispatchQueue.main.async {
+                        NotificationCenter.default.post(name: .didRescanAccount, object: nil, userInfo: nil)
+                    }
+                }
+                showAlert(vc: vc, title: "Error", message: errorDesc!)
+            } else {
+                DispatchQueue.main.async {
                     
-                    if let scanning = result["scanning"] as? NSDictionary {
+                    vc.creatingView.label.text = "confirming rescan status"
+                    
+                }
+                
+                Reducer.makeCommand(walletName: vc.wallet.name!, command: .getwalletinfo, param: "") { (object, errorDesc) in
+                    
+                    if let result = object as? NSDictionary {
                         
-                        if let _ = scanning["duration"] as? Int {
+                        if let scanning = result["scanning"] as? NSDictionary {
+                            
+                            if let _ = scanning["duration"] as? Int {
+                                
+                                vc.creatingView.removeConnectingView()
+                                let progress = (scanning["progress"] as! Double)
+                                showAlert(vc: vc, title: "Rescanning", message: "Wallet is rescanning with current progress: \((progress * 100).rounded())%")
+                                DispatchQueue.main.async {
+                                    NotificationCenter.default.post(name: .didRescanAccount, object: nil, userInfo: nil)
+                                }
+                            }
+                            
+                        } else if (result["scanning"] as? Int) == 0 {
                             
                             vc.creatingView.removeConnectingView()
-                            let progress = (scanning["progress"] as! Double)
-                            showAlert(vc: vc, title: "Rescanning", message: "Wallet is rescanning with current progress: \((progress * 100).rounded())%")
-                            NotificationCenter.default.post(name: .didRescanAccount, object: nil, userInfo: nil)
+                            showAlert(vc: vc, title: "Scan Complete", message: "The wallet is not currently scanning.")
+                            DispatchQueue.main.async {
+                                NotificationCenter.default.post(name: .didRescanAccount, object: nil, userInfo: nil)
+                            }
+                            
+                        } else {
+                            
+                            vc.creatingView.removeConnectingView()
+                            showAlert(vc: vc, title: "Error", message: "Unable to determine if wallet is rescanning.")
                             
                         }
-                        
-                    } else if (result["scanning"] as? Int) == 0 {
-                        
-                        vc.creatingView.removeConnectingView()
-                        showAlert(vc: vc, title: "Scan Complete", message: "The wallet is not currently scanning.")
-                        NotificationCenter.default.post(name: .didRescanAccount, object: nil, userInfo: nil)
                         
                     } else {
                         
                         vc.creatingView.removeConnectingView()
-                        showAlert(vc: vc, title: "Error", message: "Unable to determine if wallet is rescanning.")
+                        showAlert(vc: vc, title: "Scan Complete", message: errorDesc ?? "unknown error")
                         
                     }
-                    
-                } else {
-                    
-                    vc.creatingView.removeConnectingView()
-                    showAlert(vc: vc, title: "Scan Complete", message: errorDesc ?? "unknown error")
                     
                 }
                 
@@ -263,52 +277,68 @@ class WalletToolsViewController: UIViewController {
         
         self.creatingView.addConnectingView(vc: self, description: "initiating rescan")
         
-        Reducer.makeCommand(walletName: self.wallet.name!, command: .rescanblockchain, param: "") { [unowned vc = self] _ in
-            
-            DispatchQueue.main.async {
-                
-                vc.creatingView.label.text = "confirming rescan status"
-                
-            }
-            
-            Reducer.makeCommand(walletName: vc.wallet.name!, command: .getwalletinfo, param: "") { (object, errorDesc) in
-                
-                if let result = object as? NSDictionary {
+        Reducer.makeCommand(walletName: self.wallet.name!, command: .rescanblockchain, param: "") { [unowned vc = self] (object, errorDesc) in
+            if errorDesc != nil {
+                vc.creatingView.removeConnectingView()
+                if errorDesc!.contains("Wallet is currently rescanning") {
+                    DispatchQueue.main.async {
+                        NotificationCenter.default.post(name: .didRescanAccount, object: nil, userInfo: nil)
+                    }
+                }
+                showAlert(vc: vc, title: "Error", message: errorDesc!)
+            } else {
+                DispatchQueue.main.async {
                     
-                    if let scanning = result["scanning"] as? NSDictionary {
+                    vc.creatingView.label.text = "confirming rescan status"
+                    
+                }
+                
+                Reducer.makeCommand(walletName: vc.wallet.name!, command: .getwalletinfo, param: "") { (object, errorDesc) in
+                    
+                    if let result = object as? NSDictionary {
                         
-                        if let _ = scanning["duration"] as? Int {
+                        if let scanning = result["scanning"] as? NSDictionary {
+                            
+                            if let _ = scanning["duration"] as? Int {
+                                
+                                vc.creatingView.removeConnectingView()
+                                let progress = (scanning["progress"] as! Double)
+                                showAlert(vc: vc, title: "Rescanning", message: "Wallet is rescanning with current progress: \((progress * 100).rounded())%")
+                                DispatchQueue.main.async {
+                                    NotificationCenter.default.post(name: .didRescanAccount, object: nil, userInfo: nil)
+                                }
+                                
+                            }
+                            
+                        } else if (result["scanning"] as? Int) == 0 {
                             
                             vc.creatingView.removeConnectingView()
-                            let progress = (scanning["progress"] as! Double)
-                            showAlert(vc: vc, title: "Rescanning", message: "Wallet is rescanning with current progress: \((progress * 100).rounded())%")
-                            NotificationCenter.default.post(name: .didRescanAccount, object: nil, userInfo: nil)
+                            showAlert(vc: vc, title: "Scan Complete", message: "The wallet is not currently scanning.")
+                            DispatchQueue.main.async {
+                                NotificationCenter.default.post(name: .didRescanAccount, object: nil, userInfo: nil)
+                            }
+                            
+                        } else {
+                            
+                            vc.creatingView.removeConnectingView()
+                            showAlert(vc: vc, title: "Scan Complete", message: "Unable to determine if wallet is rescanning.")
+                            DispatchQueue.main.async {
+                                NotificationCenter.default.post(name: .didRescanAccount, object: nil, userInfo: nil)
+                            }
                             
                         }
-                        
-                    } else if (result["scanning"] as? Int) == 0 {
-                        
-                        vc.creatingView.removeConnectingView()
-                        showAlert(vc: vc, title: "Scan Complete", message: "The wallet is not currently scanning.")
-                        NotificationCenter.default.post(name: .didRescanAccount, object: nil, userInfo: nil)
                         
                     } else {
                         
                         vc.creatingView.removeConnectingView()
-                        showAlert(vc: vc, title: "Scan Complete", message: "Unable to determine if wallet is rescanning.")
-                        NotificationCenter.default.post(name: .didRescanAccount, object: nil, userInfo: nil)
+                        showAlert(vc: vc, title: "Error", message: errorDesc ?? "unknown error")
                         
                     }
                     
-                } else {
-                    
-                    vc.creatingView.removeConnectingView()
-                    showAlert(vc: vc, title: "Error", message: errorDesc ?? "unknown error")
-                    
                 }
-                
+
             }
-            
+    
         }
         
     }
@@ -328,21 +358,26 @@ class WalletToolsViewController: UIViewController {
                         vc.creatingView.removeConnectingView()
                         let progress = (scanning["progress"] as! Double)
                         showAlert(vc: vc, title: "Rescanning", message: "Wallet is rescanning with current progress: \((progress * 100).rounded())%")
-                        NotificationCenter.default.post(name: .didRescanAccount, object: nil, userInfo: nil)
-                        
+                        DispatchQueue.main.async {
+                            NotificationCenter.default.post(name: .didRescanAccount, object: nil, userInfo: nil)
+                        }
                     }
                     
                 } else if (result["scanning"] as? Int) == 0 {
                     
                     vc.creatingView.removeConnectingView()
                     showAlert(vc: vc, title: "Scan Complete", message: "Wallet not rescanning.")
-                    NotificationCenter.default.post(name: .didRescanAccount, object: nil, userInfo: nil)
+                    DispatchQueue.main.async {
+                        NotificationCenter.default.post(name: .didRescanAccount, object: nil, userInfo: nil)
+                    }
                     
                 } else {
                     
                     vc.creatingView.removeConnectingView()
                     showAlert(vc: vc, title: "Error", message: "Unable to determine if wallet is rescanning.")
-                    NotificationCenter.default.post(name: .didRescanAccount, object: nil, userInfo: nil)
+                    DispatchQueue.main.async {
+                        NotificationCenter.default.post(name: .didRescanAccount, object: nil, userInfo: nil)
+                    }
                     
                 }
                 
@@ -364,8 +399,9 @@ class WalletToolsViewController: UIViewController {
             if object != nil {
                 vc.creatingView.removeConnectingView()
                 showAlert(vc: vc, title: "Rescan aborted", message: "")
-                NotificationCenter.default.post(name: .didAbortRescan, object: nil, userInfo: nil)
-                
+                DispatchQueue.main.async {
+                    NotificationCenter.default.post(name: .didAbortRescan, object: nil, userInfo: nil)
+                }
             } else {
                 vc.creatingView.removeConnectingView()
                 showAlert(vc: vc, title: "Error", message: errorDesc ?? "unknown error")

--- a/XCode/FullyNoded2/View Controllers/Wallets/Wallets Table/WalletsViewController.swift
+++ b/XCode/FullyNoded2/View Controllers/Wallets/Wallets Table/WalletsViewController.swift
@@ -962,44 +962,44 @@ class WalletsViewController: UIViewController, UITableViewDelegate, UITableViewD
 //-------------------------------------------------------------------------------
 // MARK: - To enable mainnet accounts just uncomment the following lines of code:
 //
-//            DispatchQueue.main.async { [unowned vc = self] in
-//
-//                vc.performSegue(withIdentifier: "addWallet", sender: vc)
-//
-//            }
+            DispatchQueue.main.async { [unowned vc = self] in
+
+                vc.performSegue(withIdentifier: "addWallet", sender: vc)
+
+            }
 //-------------------------------------------------------------------------------
 // MARK: - And comment out the following lines of code:
 
-            Encryption.getNode { [unowned vc = self] (node, error) in
-
-                if !error && node != nil {
-
-                    if node!.network == "mainnet" {
-
-                        DispatchQueue.main.async {
-                            let alert = UIAlertController(title: "We appreciate your patience", message: "We are still adding new features, so mainnet wallets are disabled. Please help us test.", preferredStyle: .actionSheet)
-                            alert.addAction(UIAlertAction(title: "Understood", style: .default, handler: { action in }))
-                            alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: { action in }))
-                            vc.present(alert, animated: true, completion: nil)
-                        }
-
-                    } else {
-
-                        DispatchQueue.main.async {
-
-                            vc.performSegue(withIdentifier: "addWallet", sender: vc)
-
-                        }
-
-                    }
-
-                } else {
-
-                    displayAlert(viewController: vc, isError: true, message: "No active nodes")
-
-                }
-
-            }
+//            Encryption.getNode { [unowned vc = self] (node, error) in
+//
+//                if !error && node != nil {
+//
+//                    if node!.network == "mainnet" {
+//
+//                        DispatchQueue.main.async {
+//                            let alert = UIAlertController(title: "We appreciate your patience", message: "We are still adding new features, so mainnet wallets are disabled. Please help us test.", preferredStyle: .actionSheet)
+//                            alert.addAction(UIAlertAction(title: "Understood", style: .default, handler: { action in }))
+//                            alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: { action in }))
+//                            vc.present(alert, animated: true, completion: nil)
+//                        }
+//
+//                    } else {
+//
+//                        DispatchQueue.main.async {
+//
+//                            vc.performSegue(withIdentifier: "addWallet", sender: vc)
+//
+//                        }
+//
+//                    }
+//
+//                } else {
+//
+//                    displayAlert(viewController: vc, isError: true, message: "No active nodes")
+//
+//                }
+//
+//            }
 //-------------------------------------------------------------------------------
             
         } else {

--- a/XCode/FullyNoded2/Wallet Logic/Signers/PSBTSigner.swift
+++ b/XCode/FullyNoded2/Wallet Logic/Signers/PSBTSigner.swift
@@ -40,11 +40,11 @@ class PSBTSigner {
                         }
                     } else {
                         reset()
-                        completion((false, psbtToSign.description, nil))
+                        completion((false, nil, errorDescription))
                     }
                 } else {
                     reset()
-                    completion((false, psbtToSign.description, nil))
+                    completion((false, nil, errorDescription))
                 }
             }
         }


### PR DESCRIPTION
This PR represents general UX improvements and bug fixes.

- Newly created/imported/recovered accounts are now automatically activated
- The account view only refreshes what it needs to refresh when it needs to refresh which results in greatly improved UX
- User now has the option to add a label to recovered/imported accounts
- Fixes a bug that resulted in the rescan status from getting stuck
- Silences the "returned object is nil" error which was unnecessarily presenting when a user switched nodes/accounts
- Fix UI bug where two nodes would be toggled on simultaneously
- Fix a bug that prevented a pruned node from allowing a user to verify a transaction
- Fix a bug which attempted to return a psbt even if `finalizepsbt` failed with an error
- Fix a bug where unlocking change utxos could have resulted in a never ending spinner if no utxos existed
- Ensure accounts that are associated with the node being deactivated are deactivated when deactivating a node