### PR TITLE
Enhanced recovery: custom derivation support and sub account support.

### DIFF
--- a/XCode/GordianWallet.xcodeproj/project.pbxproj
+++ b/XCode/GordianWallet.xcodeproj/project.pbxproj
@@ -1331,7 +1331,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = GordianWallet/GordianWallet.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 0.1.63;
+				CURRENT_PROJECT_VERSION = 0.1.64;
 				DEVELOPMENT_TEAM = YZHG975W3A;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1345,7 +1345,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.63;
+				MARKETING_VERSION = 0.1.64;
 				PRODUCT_BUNDLE_IDENTIFIER = com.blockchaincommons.standupios;
 				PRODUCT_NAME = "Gordian Wallet";
 				SUPPORTS_MACCATALYST = NO;
@@ -1363,7 +1363,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = GordianWallet/GordianWallet.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 0.1.63;
+				CURRENT_PROJECT_VERSION = 0.1.64;
 				DEVELOPMENT_TEAM = YZHG975W3A;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1377,7 +1377,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.63;
+				MARKETING_VERSION = 0.1.64;
 				PRODUCT_BUNDLE_IDENTIFIER = com.blockchaincommons.standupios;
 				PRODUCT_NAME = "Gordian Wallet";
 				SUPPORTS_MACCATALYST = NO;

--- a/XCode/GordianWallet.xcodeproj/project.pbxproj
+++ b/XCode/GordianWallet.xcodeproj/project.pbxproj
@@ -1331,7 +1331,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = GordianWallet/GordianWallet.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 0.1.61;
+				CURRENT_PROJECT_VERSION = 0.1.63;
 				DEVELOPMENT_TEAM = YZHG975W3A;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1345,7 +1345,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.61;
+				MARKETING_VERSION = 0.1.63;
 				PRODUCT_BUNDLE_IDENTIFIER = com.blockchaincommons.standupios;
 				PRODUCT_NAME = "Gordian Wallet";
 				SUPPORTS_MACCATALYST = NO;
@@ -1363,7 +1363,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = GordianWallet/GordianWallet.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 0.1.61;
+				CURRENT_PROJECT_VERSION = 0.1.63;
 				DEVELOPMENT_TEAM = YZHG975W3A;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1377,7 +1377,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.61;
+				MARKETING_VERSION = 0.1.63;
 				PRODUCT_BUNDLE_IDENTIFIER = com.blockchaincommons.standupios;
 				PRODUCT_NAME = "Gordian Wallet";
 				SUPPORTS_MACCATALYST = NO;

--- a/XCode/GordianWallet.xcodeproj/project.pbxproj
+++ b/XCode/GordianWallet.xcodeproj/project.pbxproj
@@ -1331,7 +1331,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = GordianWallet/GordianWallet.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 0.1.65;
+				CURRENT_PROJECT_VERSION = 0.1.66;
 				DEVELOPMENT_TEAM = YZHG975W3A;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1345,7 +1345,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.65;
+				MARKETING_VERSION = 0.1.66;
 				PRODUCT_BUNDLE_IDENTIFIER = com.blockchaincommons.standupios;
 				PRODUCT_NAME = "Gordian Wallet";
 				SUPPORTS_MACCATALYST = NO;
@@ -1363,7 +1363,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = GordianWallet/GordianWallet.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 0.1.65;
+				CURRENT_PROJECT_VERSION = 0.1.66;
 				DEVELOPMENT_TEAM = YZHG975W3A;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1377,7 +1377,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.65;
+				MARKETING_VERSION = 0.1.66;
 				PRODUCT_BUNDLE_IDENTIFIER = com.blockchaincommons.standupios;
 				PRODUCT_NAME = "Gordian Wallet";
 				SUPPORTS_MACCATALYST = NO;

--- a/XCode/GordianWallet.xcodeproj/project.pbxproj
+++ b/XCode/GordianWallet.xcodeproj/project.pbxproj
@@ -127,6 +127,8 @@
 		D0A0EAEE23F584C8004F9E15 /* UtxoInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A0EAED23F584C8004F9E15 /* UtxoInfoViewController.swift */; };
 		D0A0EAF023F7C06E004F9E15 /* DescriptorParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A0EAEF23F7C06E004F9E15 /* DescriptorParser.swift */; };
 		D0A0EAF223F7CF70004F9E15 /* DescriptorStruct.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A0EAF123F7CF70004F9E15 /* DescriptorStruct.swift */; };
+		D0A1C99E24CFA6CB0052FFE7 /* AddressScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A1C99D24CFA6CB0052FFE7 /* AddressScanner.swift */; };
+		D0A1C9A024CFA7240052FFE7 /* CheckSubAccounts.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A1C99F24CFA7240052FFE7 /* CheckSubAccounts.swift */; };
 		D0A9EB8723F5335A00C84829 /* ChooseWalletFormatViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A9EB8623F5335A00C84829 /* ChooseWalletFormatViewController.swift */; };
 		D0B08BE6241888500025AD04 /* DonateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B08BE5241888500025AD04 /* DonateViewController.swift */; };
 		D0BFDF572490B6A600EB7846 /* LockedUtxoStruct.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0BFDF562490B6A600EB7846 /* LockedUtxoStruct.swift */; };
@@ -310,6 +312,8 @@
 		D0A0EAED23F584C8004F9E15 /* UtxoInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtxoInfoViewController.swift; sourceTree = "<group>"; };
 		D0A0EAEF23F7C06E004F9E15 /* DescriptorParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DescriptorParser.swift; sourceTree = "<group>"; };
 		D0A0EAF123F7CF70004F9E15 /* DescriptorStruct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DescriptorStruct.swift; sourceTree = "<group>"; };
+		D0A1C99D24CFA6CB0052FFE7 /* AddressScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressScanner.swift; sourceTree = "<group>"; };
+		D0A1C99F24CFA7240052FFE7 /* CheckSubAccounts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckSubAccounts.swift; sourceTree = "<group>"; };
 		D0A9EB8623F5335A00C84829 /* ChooseWalletFormatViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooseWalletFormatViewController.swift; sourceTree = "<group>"; };
 		D0B08BE5241888500025AD04 /* DonateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DonateViewController.swift; sourceTree = "<group>"; };
 		D0BFDF562490B6A600EB7846 /* LockedUtxoStruct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockedUtxoStruct.swift; sourceTree = "<group>"; };
@@ -687,6 +691,8 @@
 				D04179F024762A460096F74D /* bc-b32 */,
 				D0D5E63C24A07E4600F3783C /* WalletStatus.swift */,
 				D0C20EE824A82B7000C62AA4 /* TransactionFetcher.swift */,
+				D0A1C99D24CFA6CB0052FFE7 /* AddressScanner.swift */,
+				D0A1C99F24CFA7240052FFE7 /* CheckSubAccounts.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -1128,6 +1134,7 @@
 				D09D736023F0F3C000847DC8 /* KeyPad.swift in Sources */,
 				D047DE09242C5906004BC26D /* WalletCreatedQRViewController.swift in Sources */,
 				D09DCF6823F1072A008F5B9F /* KeyGen.swift in Sources */,
+				D0A1C99E24CFA6CB0052FFE7 /* AddressScanner.swift in Sources */,
 				D047DE07242C478A004BC26D /* WalletCreatedSuccessViewController.swift in Sources */,
 				D09D736823F0F3C000847DC8 /* MultiSigTxBuilder.swift in Sources */,
 				D006E34B243ED2FE007B1A5B /* Keychain.swift in Sources */,
@@ -1158,6 +1165,7 @@
 				D0502FF024500DE000213870 /* AddExtendedKeyViewController.swift in Sources */,
 				D0B08BE6241888500025AD04 /* DonateViewController.swift in Sources */,
 				D047DDFB242B324A004BC26D /* WhatIsFN2ViewController.swift in Sources */,
+				D0A1C9A024CFA7240052FFE7 /* CheckSubAccounts.swift in Sources */,
 				D05650082441A78E00754ACF /* VerifyKeysViewController.swift in Sources */,
 				D0D561FD24306B060085E3CC /* RefillMultiSig.swift in Sources */,
 				D09D735E23F0F3C000847DC8 /* QRGenerator.swift in Sources */,
@@ -1323,7 +1331,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = GordianWallet/GordianWallet.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 0.1.59;
+				CURRENT_PROJECT_VERSION = 0.1.61;
 				DEVELOPMENT_TEAM = YZHG975W3A;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1337,7 +1345,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.59;
+				MARKETING_VERSION = 0.1.61;
 				PRODUCT_BUNDLE_IDENTIFIER = com.blockchaincommons.standupios;
 				PRODUCT_NAME = "Gordian Wallet";
 				SUPPORTS_MACCATALYST = NO;
@@ -1355,7 +1363,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = GordianWallet/GordianWallet.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 0.1.59;
+				CURRENT_PROJECT_VERSION = 0.1.61;
 				DEVELOPMENT_TEAM = YZHG975W3A;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1369,7 +1377,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.59;
+				MARKETING_VERSION = 0.1.61;
 				PRODUCT_BUNDLE_IDENTIFIER = com.blockchaincommons.standupios;
 				PRODUCT_NAME = "Gordian Wallet";
 				SUPPORTS_MACCATALYST = NO;

--- a/XCode/GordianWallet.xcodeproj/project.pbxproj
+++ b/XCode/GordianWallet.xcodeproj/project.pbxproj
@@ -1331,7 +1331,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = GordianWallet/GordianWallet.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 0.1.64;
+				CURRENT_PROJECT_VERSION = 0.1.65;
 				DEVELOPMENT_TEAM = YZHG975W3A;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1345,7 +1345,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.64;
+				MARKETING_VERSION = 0.1.65;
 				PRODUCT_BUNDLE_IDENTIFIER = com.blockchaincommons.standupios;
 				PRODUCT_NAME = "Gordian Wallet";
 				SUPPORTS_MACCATALYST = NO;
@@ -1363,7 +1363,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = GordianWallet/GordianWallet.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 0.1.64;
+				CURRENT_PROJECT_VERSION = 0.1.65;
 				DEVELOPMENT_TEAM = YZHG975W3A;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1377,7 +1377,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.64;
+				MARKETING_VERSION = 0.1.65;
 				PRODUCT_BUNDLE_IDENTIFIER = com.blockchaincommons.standupios;
 				PRODUCT_NAME = "Gordian Wallet";
 				SUPPORTS_MACCATALYST = NO;

--- a/XCode/GordianWallet/Helpers/AddressScanner.swift
+++ b/XCode/GordianWallet/Helpers/AddressScanner.swift
@@ -1,0 +1,58 @@
+//
+//  AddressScanner.swift
+//  GordianWallet
+//
+//  Created by Peter on 28/07/20.
+//  Copyright © 2020 Blockchain Commons, LLC. All rights reserved.
+//
+
+import Foundation
+
+class AddressScanner {
+    static let sharedInstance = AddressScanner()
+    lazy var torClient = TorClient.sharedInstance
+
+     func scan(address: String, completion: @escaping ((Bool?)) -> Void) {
+        Encryption.getNode { [unowned vc = self] (node, error) in
+            if node != nil {
+                var blockstreamUrl = "http://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion/api/address/"
+                if node!.network == "testnet" {
+                    blockstreamUrl = "http://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion/testnet/api/address/"
+                }
+                blockstreamUrl += address
+                guard let url = URL(string: blockstreamUrl) else {
+                    completion((nil))
+                    return
+                }
+                var request = URLRequest(url: url)
+                request.httpMethod = "GET"
+                request.setValue("text/plain", forHTTPHeaderField: "Content-Type")
+                let task = vc.torClient.session.dataTask(with: request as URLRequest) { (data, response, error) in
+                    if error != nil {
+                        completion(nil)
+                    } else {
+                        if let urlContent = data {
+                            do {
+                                let dict = try JSONSerialization.jsonObject(with: urlContent, options: JSONSerialization.ReadingOptions.mutableLeaves) as! NSDictionary
+                                if let chainStats = dict["chain_stats"] as? NSDictionary {
+                                    if let txCount = chainStats["tx_count"] as? Int {
+                                        if txCount > 0 {
+                                            completion(true)
+                                        } else {
+                                            completion(false)
+                                        }
+                                    }
+                                }
+                            } catch {
+                                completion(nil)
+                            }
+                        }
+                    }
+                }
+                task.resume()
+            } else {
+                completion(nil)
+            }
+        }
+    }
+}

--- a/XCode/GordianWallet/Helpers/CheckSubAccounts.swift
+++ b/XCode/GordianWallet/Helpers/CheckSubAccounts.swift
@@ -1,0 +1,80 @@
+//
+//  CheckSubAccounts.swift
+//  GordianWallet
+//
+//  Created by Peter on 28/07/20.
+//  Copyright © 2020 Blockchain Commons, LLC. All rights reserved.
+//
+
+import Foundation
+
+class CheckSubAccounts {
+    
+    class func check(derivation: String, words: String, coinType: String, completion: @escaping (([[String:Any]]?)) -> Void) {
+        
+        let bip84 = "m/84'/\(coinType)'/0'/0/0"
+        let bip44 = "m/44'/\(coinType)'/0'/0/0"
+        let bip49 = "m/49'/\(coinType)'/0'/0/0"
+        
+        var derivsToScan:[[String:Any]] = []
+        let derivations = [["derivation":bip84, "addresses":[], "hasHistory":false],  ["derivation":bip44, "addresses":[], "hasHistory":false], ["derivation": bip49, "addresses":[], "hasHistory":false]] as [[String:Any]]
+        
+        for deriv in derivations {
+            if !(deriv["derivation"] as! String).contains(derivation) {
+                derivsToScan.append(deriv)
+            }
+        }
+        
+        var addressesIndex = 0
+        var balancesIndex = 0
+        
+        func fetchBalances(index: Int, addressIndex: Int) {
+            if balancesIndex < derivsToScan.count {
+                let addresses = derivsToScan[index]["addresses"] as! [String]
+                if addressesIndex < addresses.count {
+                    let shared = AddressScanner.sharedInstance
+                    shared.scan(address: addresses[addressesIndex]) { (hasHistory) in
+                        if hasHistory != nil {
+                            if hasHistory! {
+                                derivsToScan[index]["hasHistory"] = true
+                                completion(derivsToScan)
+                            } else {
+                                addressesIndex += 1
+                                if addressesIndex == addresses.count {
+                                    balancesIndex += 1
+                                }
+                                fetchBalances(index: index, addressIndex: addressesIndex)
+                            }
+                        }
+                    }
+                } else {
+                    addressesIndex = 0
+                    fetchBalances(index: balancesIndex, addressIndex: addressesIndex)
+                }
+            } else {
+                completion(derivsToScan)
+            }
+        }
+        
+        var fetchIndex = 0
+        func fetchAddresses(index: Int) {
+            if index < derivsToScan.count {
+                KeyFetcher.fetchAddresses(words: words, derivation: (derivsToScan[index]["derivation"] as! String)) { (addresses) in
+                    if addresses != nil {
+                        derivsToScan[index]["addresses"] = addresses!
+                        fetchIndex += 1
+                        fetchAddresses(index: fetchIndex)
+                    } else {
+                        completion(nil)
+                    }
+                }
+            } else {
+                fetchBalances(index: 0, addressIndex: 0)
+            }
+        }
+        
+        fetchAddresses(index: fetchIndex)
+        
+    }
+    
+}

--- a/XCode/GordianWallet/Helpers/KeyFetcher.swift
+++ b/XCode/GordianWallet/Helpers/KeyFetcher.swift
@@ -296,5 +296,40 @@ class KeyFetcher {
             }
         }
     }
+    
+    class func fetchAddresses(words: String, derivation: String, completion: @escaping (([String]?)) -> Void) {
+        var addresses:[String] = []
+        if let bip39mnemonic = BIP39Mnemonic(words) {
+            let seed = bip39mnemonic.seedHex("")
+            var addressType:AddressType!
+            if let mk = HDKey(seed, .testnet) {
+                if derivation.contains("49") {
+                    addressType = .payToScriptHashPayToWitnessPubKeyHash
+                } else if derivation.contains("44") {
+                    addressType = .payToPubKeyHash
+                } else if derivation.contains("84") {
+                    addressType = .payToWitnessPubKeyHash
+                } else {
+                    completion(nil)
+                }
+                if let path = BIP32Path(derivation) {
+                    do {
+                        let key = try mk.derive(path)
+                        let address = key.address(addressType)
+                        addresses.append(address.description)
+                        completion(addresses)
+                    } catch {
+                        completion(nil)
+                    }
+                } else {
+                    completion(nil)
+                }
+            } else {
+                completion(nil)
+            }
+        } else {
+            completion(nil)
+        }
+    }
 
 }

--- a/XCode/GordianWallet/Helpers/Reducer.swift
+++ b/XCode/GordianWallet/Helpers/Reducer.swift
@@ -22,7 +22,7 @@ class Reducer {
         func torCommand() {
             
             let torRPC = MakeRPCCall.sharedInstance
-            torRPC.executeRPCCommand(walletName: walletName, method: command, param: param) { (success, objectToReturn, errorDesc) in
+            torRPC.executeRPCCommand(walletName: walletName, method: command, param: param) { (success, objectToReturn, errorDesccription) in
                 
                 if success && objectToReturn != nil {
                     
@@ -30,9 +30,9 @@ class Reducer {
                     
                 } else {
                     
-                    if errorDesc != nil {
+                    if errorDesccription != nil {
                         
-                        if errorDesc!.contains("Requested wallet does not exist or is not loaded") {
+                        if errorDesccription!.contains("Requested wallet does not exist or is not loaded") {
                             
                             torRPC.executeRPCCommand(walletName: walletName, method: .loadwallet, param: "\"\(walletName)\"") { (success, objectToReturn, errorDesc) in
                                 
@@ -62,13 +62,13 @@ class Reducer {
                             
                         } else {
                             
-                            completion((nil, errorDesc!))
+                            completion((nil, errorDesccription!))
                             
                         }
                         
                     } else {
                         
-                        completion((nil, errorDesc!))
+                        completion((nil, errorDesccription!))
                         
                     }
                     

--- a/XCode/GordianWallet/Helpers/SeedParser.swift
+++ b/XCode/GordianWallet/Helpers/SeedParser.swift
@@ -215,40 +215,18 @@ class SeedParser {
             }
         }
                 
-        if wallet.xprv != nil {
-            derivation = "0/0"
-            
-            guard let bip32path = BIP32Path(derivation) else {
+        derivation = wallet.derivation
+        
+        guard let bip32path = BIP32Path(derivation) else {
+            completion((nil, nil))
+            return
+        }
+        
+        Encryption.decryptedSeeds { (decryptedSeeds) in
+            if decryptedSeeds != nil {
+                checkMnemonics(seeds: decryptedSeeds!, bip32Path: bip32path)
+            } else {
                 completion((nil, nil))
-                return
-            }
-            
-            Encryption.decryptData(dataToDecrypt: wallet.xprv!) { (decryptedXprv) in
-                if decryptedXprv != nil {
-                    if let xprv = String(bytes: decryptedXprv!, encoding: .utf8) {
-                        checkXprv(xprv: xprv, bip32Path: bip32path)
-                    } else {
-                        completion((nil, nil))
-                    }
-                } else {
-                    completion((nil, nil))
-                }
-            }
-            
-        } else {
-            derivation = wallet.derivation
-            
-            guard let bip32path = BIP32Path(derivation) else {
-                completion((nil, nil))
-                return
-            }
-            
-            Encryption.decryptedSeeds { (decryptedSeeds) in
-                if decryptedSeeds != nil {
-                    checkMnemonics(seeds: decryptedSeeds!, bip32Path: bip32path)
-                } else {
-                    completion((nil, nil))
-                }
             }
         }
     }

--- a/XCode/GordianWallet/Main.storyboard
+++ b/XCode/GordianWallet/Main.storyboard
@@ -31,7 +31,7 @@
         <!--Public Keys & Addresses-->
         <scene sceneID="ldE-LN-HUc">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="jX1-Is-hS7" customClass="ExportKeysViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="jX1-Is-hS7" customClass="ExportKeysViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Zzb-On-WiQ">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -356,7 +356,7 @@
         <!--Authenticate-->
         <scene sceneID="uhr-cc-fch">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="FI5-Kv-Y72" customClass="AuthenticateViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="FI5-Kv-Y72" customClass="AuthenticateViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="xx3-cn-bLQ">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -372,7 +372,7 @@
         <!--Home-->
         <scene sceneID="erx-5N-Kcy">
             <objects>
-                <viewController storyboardIdentifier="MainMenu" extendedLayoutIncludesOpaqueBars="YES" useStoryboardIdentifierAsRestorationIdentifier="YES" id="XmP-lK-cua" customClass="MainMenuViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="MainMenu" extendedLayoutIncludesOpaqueBars="YES" useStoryboardIdentifierAsRestorationIdentifier="YES" id="XmP-lK-cua" customClass="MainMenuViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Xal-ei-X51">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -1057,7 +1057,7 @@
         <!--Notification Center View Controller-->
         <scene sceneID="LYy-PL-AbR">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="Jrh-wd-oba" customClass="NotificationCenterViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="Jrh-wd-oba" customClass="NotificationCenterViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="F9S-Uk-itD">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -1155,7 +1155,7 @@
         <!--Notification Detail View Controller-->
         <scene sceneID="nA0-8m-dJp">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="44j-JA-eKl" customClass="NotificationDetailViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="44j-JA-eKl" customClass="NotificationDetailViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="svN-4f-zp7">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -1237,7 +1237,7 @@
         <!--Introduction View Controller-->
         <scene sceneID="xwq-yX-n8x">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="I2N-Ql-8qz" customClass="IntroductionViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="I2N-Ql-8qz" customClass="IntroductionViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="brz-ev-3wV">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -1318,7 +1318,7 @@ We appreciate your attention and patience!</string>
         <!--What IsFN2 View Controller-->
         <scene sceneID="WHW-Pc-Ddb">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="bbG-OT-g8S" customClass="WhatIsFN2ViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="bbG-OT-g8S" customClass="WhatIsFN2ViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="oTR-K6-o1V">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -1411,7 +1411,7 @@ For more information regarding wallet recovery please see our Recovery.md file.<
         <!--How To SupportFN2 View Controller-->
         <scene sceneID="zot-p1-6np">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="2py-0n-Ew1" customClass="HowToSupportFN2ViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="2py-0n-Ew1" customClass="HowToSupportFN2ViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="gvZ-RO-lUM">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -1490,7 +1490,7 @@ If you find this project useful, and would like to learn more about Blockchain C
         <!--How To UseFN2 View Controller-->
         <scene sceneID="qpf-OM-Fdc">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="2h3-RM-OBN" customClass="HowToUseFN2ViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="2h3-RM-OBN" customClass="HowToUseFN2ViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="30J-zW-bYp">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -1567,7 +1567,7 @@ The app will then do all the hard work for you. Using FullyNoded 2 is straightfo
         <!--IsFN2 Secure View Controller-->
         <scene sceneID="MMT-Gw-vBb">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="HFs-mJ-jw5" customClass="IsFN2SecureViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="HFs-mJ-jw5" customClass="IsFN2SecureViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="uyg-gE-hOL">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -1646,7 +1646,7 @@ FullyNoded 2 utilizes the latest generation of hidden services and allows you to
         <!--License Disclaimer View Controller-->
         <scene sceneID="GsQ-g5-4MW">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="Ll8-ZN-VE5" customClass="LicenseDisclaimerViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="Ll8-ZN-VE5" customClass="LicenseDisclaimerViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tnV-vd-CtN">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -1744,7 +1744,7 @@ The use of FullyNoded 2 is under the "BSD 2-Clause Plus Patent License" (https:/
         <!--Sign In View Controller-->
         <scene sceneID="lI8-y0-g1b">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="Z5o-kT-X3Z" customClass="SignInViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="Z5o-kT-X3Z" customClass="SignInViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="jWO-gu-MiD">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -1845,7 +1845,7 @@ Blockchain Commons and Fully Noded 2 never share any data with any third party e
         <!--Donate View Controller-->
         <scene sceneID="7jc-m3-rrH">
             <objects>
-                <viewController id="NHv-UH-1lX" customClass="DonateViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="NHv-UH-1lX" customClass="DonateViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="P8x-W2-8Ap">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -1957,7 +1957,7 @@ You can either support us by becoming a GitHub sponsor, where GitHub is matching
         <!--Transaction-->
         <scene sceneID="VqF-ym-nmL">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="MkV-nj-qUL" customClass="TransactionViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="MkV-nj-qUL" customClass="TransactionViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="gzX-0t-QhJ">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -2106,7 +2106,7 @@ You can either support us by becoming a GitHub sponsor, where GitHub is matching
         <!--Scanner View Controller-->
         <scene sceneID="S5B-qY-ww0">
             <objects>
-                <viewController hidesBottomBarWhenPushed="YES" id="o69-RN-9VD" customClass="ScannerViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController hidesBottomBarWhenPushed="YES" id="o69-RN-9VD" customClass="ScannerViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tBq-5k-T1U">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="525"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -2160,7 +2160,7 @@ You can either support us by becoming a GitHub sponsor, where GitHub is matching
         <!--Invoice-->
         <scene sceneID="aU3-2L-A1l">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" id="Xxg-Pp-vvN" customClass="InvoiceViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" id="Xxg-Pp-vvN" customClass="InvoiceViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="eUN-hK-8St">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -2315,7 +2315,7 @@ You can either support us by becoming a GitHub sponsor, where GitHub is matching
         <!--Build Transaction-->
         <scene sceneID="nPC-E2-jSN">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" id="pUo-bf-sNm" customClass="CreateRawTxViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" id="pUo-bf-sNm" customClass="CreateRawTxViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="DIN-Fg-EH6">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -2587,7 +2587,7 @@ You can either support us by becoming a GitHub sponsor, where GitHub is matching
         <!--Confirm-->
         <scene sceneID="cYH-Od-C1K">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="xB3-mY-13p" customClass="ConfirmViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="xB3-mY-13p" customClass="ConfirmViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="T5K-PU-RA6">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -2794,7 +2794,7 @@ You can either support us by becoming a GitHub sponsor, where GitHub is matching
         <!--Verify-->
         <scene sceneID="i2z-D9-ciK">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="J96-pV-r6d" customClass="VerifyViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="J96-pV-r6d" customClass="VerifyViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="XGu-4Z-bs0">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -2828,7 +2828,7 @@ You can either support us by becoming a GitHub sponsor, where GitHub is matching
         <!--Settings-->
         <scene sceneID="Ajv-p7-tUm">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="AS8-ke-Yxh" customClass="SettingsViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="AS8-ke-Yxh" customClass="SettingsViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="A3f-zZ-K5e">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -2942,7 +2942,7 @@ You can either support us by becoming a GitHub sponsor, where GitHub is matching
         <!--Backup Info-->
         <scene sceneID="whf-ed-7JK">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="lq5-Pd-gqW" customClass="SeedViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="lq5-Pd-gqW" customClass="SeedViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="GDk-pd-kDa">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -3069,7 +3069,7 @@ You can either support us by becoming a GitHub sponsor, where GitHub is matching
         <!--Wallet Created Success View Controller-->
         <scene sceneID="kKT-Sa-QMY">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="shH-Cs-byi" customClass="WalletCreatedSuccessViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="shH-Cs-byi" customClass="WalletCreatedSuccessViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="vnd-UJ-Nms">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -3156,7 +3156,7 @@ You should make mutliple backups of each and store them in seperate locations.</
         <!--Account Map QR-->
         <scene sceneID="zcX-u3-cQY">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="M6J-Vn-XJt" customClass="WalletCreatedQRViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="M6J-Vn-XJt" customClass="WalletCreatedQRViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="9i8-aS-4OV">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -3224,7 +3224,7 @@ It holds your wallets PUBLIC KEYS, and can not be used to spend funds! In order 
         <!--Node's Seed-->
         <scene sceneID="2Mt-d4-dcm">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="Ko8-An-eKd" customClass="WalletCreatedNodesSeedViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="Ko8-An-eKd" customClass="WalletCreatedNodesSeedViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="PGI-D8-S3B">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -3381,7 +3381,7 @@ It holds your wallets PUBLIC KEYS, and can not be used to spend funds! In order 
         <!--Offline Seed-->
         <scene sceneID="Mbu-zT-oG5">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="pka-dK-9G9" customClass="WalletCreatedSaveWordsViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="pka-dK-9G9" customClass="WalletCreatedSaveWordsViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="OOS-O4-V6n">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -3534,7 +3534,7 @@ It holds your wallets PUBLIC KEYS, and can not be used to spend funds! In order 
         <!--Seed Words-->
         <scene sceneID="PTw-4b-9Ka">
             <objects>
-                <viewController hidesBottomBarWhenPushed="YES" id="94S-m3-HcE" customClass="WalletCreatedWordsViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController hidesBottomBarWhenPushed="YES" id="94S-m3-HcE" customClass="WalletCreatedWordsViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="rIJ-HM-PbH">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -3593,7 +3593,7 @@ At a minimum we recommend writing these words down on water proof paper with a p
         <!--Choose Number Of Signers View Controller-->
         <scene sceneID="3oC-l5-4EA">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="1BI-xh-FzJ" customClass="ChooseNumberOfSignersViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="1BI-xh-FzJ" customClass="ChooseNumberOfSignersViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="S7c-n6-Cfw">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -3635,7 +3635,7 @@ At a minimum we recommend writing these words down on water proof paper with a p
         <!--Confirm-->
         <scene sceneID="ksL-eU-VG9">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="0g2-8e-jCH" customClass="ConfirmRecoveryViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="0g2-8e-jCH" customClass="ConfirmRecoveryViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Vhf-Xe-5bf">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -3893,7 +3893,7 @@ At a minimum we recommend writing these words down on water proof paper with a p
         <!--Locked UTXO Info-->
         <scene sceneID="MG3-9N-gz0">
             <objects>
-                <viewController hidesBottomBarWhenPushed="YES" id="IhZ-EY-NJ5" customClass="LockedUtxosViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController hidesBottomBarWhenPushed="YES" id="IhZ-EY-NJ5" customClass="LockedUtxosViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Tnt-2b-ReQ">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -3927,7 +3927,7 @@ At a minimum we recommend writing these words down on water proof paper with a p
         <!--Export-->
         <scene sceneID="txy-Zb-nWB">
             <objects>
-                <viewController id="aWn-Fx-ACR" customClass="QRViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="aWn-Fx-ACR" customClass="QRViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="0ft-op-zNI">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -3970,7 +3970,7 @@ At a minimum we recommend writing these words down on water proof paper with a p
         <!--Node Manager-->
         <scene sceneID="xYz-bt-Lyj">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="DOn-IQ-sOy" customClass="NodeManagerViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="DOn-IQ-sOy" customClass="NodeManagerViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="VaW-dM-vZL">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -4044,7 +4044,7 @@ At a minimum we recommend writing these words down on water proof paper with a p
         <!--Recovery-->
         <scene sceneID="k9E-E2-70I">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="Elr-wf-cyI" customClass="WalletRecoverViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="Elr-wf-cyI" customClass="WalletRecoverViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="JxN-8Z-mkw">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -4127,7 +4127,7 @@ At a minimum we recommend writing these words down on water proof paper with a p
         <!--Seed Words-->
         <scene sceneID="zAi-gs-cRc">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="kR7-Mg-fhs" customClass="WordRecoveryViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="kR7-Mg-fhs" customClass="WordRecoveryViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="PCf-Oj-I0Q">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -4198,7 +4198,7 @@ At a minimum we recommend writing these words down on water proof paper with a p
         <!--Displayer View Controller-->
         <scene sceneID="2P1-G0-q27">
             <objects>
-                <viewController id="WYx-vx-5xJ" customClass="QRDisplayerViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="WYx-vx-5xJ" customClass="QRDisplayerViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Nlx-Rv-vA1">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -4214,7 +4214,7 @@ At a minimum we recommend writing these words down on water proof paper with a p
         <!--Tools-->
         <scene sceneID="s4f-Br-O6C">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="51a-bL-HRe" customClass="WalletToolsViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="51a-bL-HRe" customClass="WalletToolsViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="gv9-ry-GoN">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -4460,7 +4460,7 @@ At a minimum we recommend writing these words down on water proof paper with a p
         <!--Refill Keypool-->
         <scene sceneID="GrC-rC-yST">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="reL-7P-R3q" customClass="RefillMultisigViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="reL-7P-R3q" customClass="RefillMultisigViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="ZRF-hf-jJd">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -4560,7 +4560,7 @@ At a minimum we recommend writing these words down on water proof paper with a p
         <!--Sweep to-->
         <scene sceneID="pAe-Ty-iWF">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="dWg-DF-dx5" customClass="SweepToViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="dWg-DF-dx5" customClass="SweepToViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="OjN-Hs-8o0">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -4777,7 +4777,7 @@ At a minimum we recommend writing these words down on water proof paper with a p
         <!--Accounts-->
         <scene sceneID="xPx-UU-NTd">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" modalPresentationStyle="fullScreen" id="3uQ-0D-YgM" customClass="WalletsViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" modalPresentationStyle="fullScreen" id="3uQ-0D-YgM" customClass="WalletsViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="xno-0v-9NB">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -5571,7 +5571,7 @@ At a minimum we recommend writing these words down on water proof paper with a p
         <!--Create Account-->
         <scene sceneID="lEx-cV-voz">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="20O-ZD-xtI" customClass="ChooseWalletFormatViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="20O-ZD-xtI" customClass="ChooseWalletFormatViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="3Xx-cw-zsB">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -5778,7 +5778,7 @@ At a minimum we recommend writing these words down on water proof paper with a p
         <!--Add xpub-->
         <scene sceneID="JBr-sN-uMP">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="QV1-we-EJN" customClass="AddExtendedKeyViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="QV1-we-EJN" customClass="AddExtendedKeyViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="ULy-HG-wOq">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -5915,7 +5915,7 @@ At a minimum we recommend writing these words down on water proof paper with a p
         <!--UTXO Info-->
         <scene sceneID="gUA-vw-Rw5">
             <objects>
-                <viewController hidesBottomBarWhenPushed="YES" id="w66-ss-9Kp" customClass="UtxoInfoViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController hidesBottomBarWhenPushed="YES" id="w66-ss-9Kp" customClass="UtxoInfoViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Trb-Ca-aYc">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -5949,7 +5949,7 @@ At a minimum we recommend writing these words down on water proof paper with a p
         <!--UTXO's-->
         <scene sceneID="WAZ-Eh-cw6">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="qYd-Xi-rqO" customClass="UTXOViewController" customModule="FullyNoded_2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController extendedLayoutIncludesOpaqueBars="YES" hidesBottomBarWhenPushed="YES" id="qYd-Xi-rqO" customClass="UTXOViewController" customModule="Gordian_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Mo7-j4-oZL">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -6245,7 +6245,7 @@ At a minimum we recommend writing these words down on water proof paper with a p
         <segue reference="NHy-Xu-LiC"/>
         <segue reference="c5y-jb-z8M"/>
         <segue reference="2kH-rb-1zK"/>
-        <segue reference="Xe1-Me-c8c"/>
+        <segue reference="OVL-GL-HPC"/>
         <segue reference="zkr-zY-rLG"/>
     </inferredMetricsTieBreakers>
     <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/XCode/GordianWallet/Main.storyboard
+++ b/XCode/GordianWallet/Main.storyboard
@@ -4163,28 +4163,57 @@ At a minimum we recommend writing these words down on water proof paper with a p
                                 </connections>
                             </button>
                             <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ir0-SX-h8D">
-                                <rect key="frame" x="16" y="119" width="343" height="477"/>
+                                <rect key="frame" x="16" y="119" width="343" height="377"/>
                                 <color key="backgroundColor" red="0.06801593996529115" green="0.089767907349853029" blue="0.098156708180203167" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </view>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="custom derivations are optional and for expert users only, leave it blank to stick with the defaults (recommended)." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="08W-8g-1NG">
+                                <rect key="frame" x="16" y="575" width="343" height="35"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="35" id="m82-hX-dXM"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Custom derivation: (optional)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ocn-cO-Dth">
+                                <rect key="frame" x="16" y="504" width="222" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="optional" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="dUC-de-xB5">
+                                <rect key="frame" x="16" y="533" width="343" height="34"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardAppearance="alert" returnKeyType="done" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
+                            </textField>
                         </subviews>
                         <color key="backgroundColor" red="0.038850985470000002" green="0.050955481830000003" blue="0.055168129500000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
+                            <constraint firstItem="ocn-cO-Dth" firstAttribute="top" secondItem="Ir0-SX-h8D" secondAttribute="bottom" constant="8" id="1ng-LH-XHU"/>
+                            <constraint firstItem="08W-8g-1NG" firstAttribute="top" secondItem="dUC-de-xB5" secondAttribute="bottom" constant="8" id="4lx-z2-VyZ"/>
                             <constraint firstItem="Gyn-mg-Z8d" firstAttribute="centerY" secondItem="1n6-iJ-uNl" secondAttribute="centerY" id="9Z3-HC-hg6"/>
                             <constraint firstItem="gfM-eP-RM3" firstAttribute="trailing" secondItem="Ir0-SX-h8D" secondAttribute="trailing" constant="16" id="A1h-UH-Hdv"/>
                             <constraint firstItem="Ir0-SX-h8D" firstAttribute="top" secondItem="Gyn-mg-Z8d" secondAttribute="bottom" constant="21" id="A4u-jD-rmB"/>
-                            <constraint firstItem="gfM-eP-RM3" firstAttribute="bottom" secondItem="Ir0-SX-h8D" secondAttribute="bottom" constant="22" id="bL8-t7-qyO"/>
+                            <constraint firstItem="gfM-eP-RM3" firstAttribute="trailing" secondItem="08W-8g-1NG" secondAttribute="trailing" constant="16" id="MAP-Wc-c3e"/>
+                            <constraint firstItem="ocn-cO-Dth" firstAttribute="leading" secondItem="gfM-eP-RM3" secondAttribute="leading" constant="16" id="dnQ-88-FdN"/>
+                            <constraint firstItem="dUC-de-xB5" firstAttribute="leading" secondItem="gfM-eP-RM3" secondAttribute="leading" constant="16" id="dqk-31-S2Z"/>
                             <constraint firstItem="gfM-eP-RM3" firstAttribute="trailing" secondItem="ftm-bz-o4y" secondAttribute="trailing" constant="16" id="g5N-nw-jv1"/>
                             <constraint firstItem="1n6-iJ-uNl" firstAttribute="leading" secondItem="gfM-eP-RM3" secondAttribute="leading" constant="16" id="h0c-Bb-ugj"/>
                             <constraint firstItem="ftm-bz-o4y" firstAttribute="leading" secondItem="Gyn-mg-Z8d" secondAttribute="trailing" constant="14" id="hkY-UQ-Lc2"/>
                             <constraint firstItem="Gyn-mg-Z8d" firstAttribute="leading" secondItem="1n6-iJ-uNl" secondAttribute="trailing" constant="13" id="jL0-s0-n8K"/>
+                            <constraint firstItem="gfM-eP-RM3" firstAttribute="trailing" secondItem="dUC-de-xB5" secondAttribute="trailing" constant="16" id="kYU-Q7-QqW"/>
                             <constraint firstItem="Ir0-SX-h8D" firstAttribute="leading" secondItem="gfM-eP-RM3" secondAttribute="leading" constant="16" id="oHL-HZ-gvA"/>
                             <constraint firstItem="Gyn-mg-Z8d" firstAttribute="top" secondItem="gfM-eP-RM3" secondAttribute="top" constant="20" id="pQo-Ug-KXj"/>
+                            <constraint firstItem="08W-8g-1NG" firstAttribute="leading" secondItem="gfM-eP-RM3" secondAttribute="leading" constant="16" id="rXh-Yc-NuO"/>
                             <constraint firstItem="ftm-bz-o4y" firstAttribute="centerY" secondItem="1n6-iJ-uNl" secondAttribute="centerY" id="tC8-ia-lJ6"/>
+                            <constraint firstItem="gfM-eP-RM3" firstAttribute="bottom" secondItem="08W-8g-1NG" secondAttribute="bottom" constant="8" id="yoh-4s-Tij"/>
+                            <constraint firstItem="dUC-de-xB5" firstAttribute="top" secondItem="ocn-cO-Dth" secondAttribute="bottom" constant="8" id="zuI-Gh-fU4"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="gfM-eP-RM3"/>
                     </view>
                     <navigationItem key="navigationItem" title="Seed Words" id="3Du-fY-hLc"/>
                     <connections>
+                        <outlet property="derivationField" destination="dUC-de-xB5" id="1UC-9T-YbT"/>
                         <outlet property="textField" destination="Gyn-mg-Z8d" id="ykG-0f-liV"/>
                         <outlet property="wordView" destination="Ir0-SX-h8D" id="MbA-iZ-B10"/>
                         <segue destination="0g2-8e-jCH" kind="show" identifier="confirmFromWords" id="9aM-UA-Kws"/>
@@ -4193,7 +4222,7 @@ At a minimum we recommend writing these words down on water proof paper with a p
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="gR4-VF-d5h" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-3546" y="1828"/>
+            <point key="canvasLocation" x="-3546.4000000000001" y="1827.4362818590705"/>
         </scene>
         <!--Displayer View Controller-->
         <scene sceneID="2P1-G0-q27">
@@ -6241,8 +6270,8 @@ At a minimum we recommend writing these words down on water proof paper with a p
         <segue reference="Kzq-6W-yKR"/>
         <segue reference="7qw-Ys-xsH"/>
         <segue reference="EvJ-Lj-YLy"/>
-        <segue reference="ONV-Bz-eml"/>
-        <segue reference="NHy-Xu-LiC"/>
+        <segue reference="9aM-UA-Kws"/>
+        <segue reference="G4m-Sr-i7G"/>
         <segue reference="c5y-jb-z8M"/>
         <segue reference="2kH-rb-1zK"/>
         <segue reference="OVL-GL-HPC"/>

--- a/XCode/GordianWallet/View Controllers/Home Screen/MainMenuViewController.swift
+++ b/XCode/GordianWallet/View Controllers/Home Screen/MainMenuViewController.swift
@@ -63,6 +63,7 @@ class MainMenuViewController: UIViewController, UITableViewDelegate, UITableView
         showFiat = false
         torConnected = false
         mainMenu.delegate = self
+        mainMenu.alpha = 0
         tabBarController?.delegate = self
         navigationController?.delegate = self
         NotificationCenter.default.addObserver(self, selector: #selector(torBootStrapping(_:)), name: .didStartBootstrappingTor, object: nil)
@@ -1670,6 +1671,9 @@ class MainMenuViewController: UIViewController, UITableViewDelegate, UITableView
     }
     
     func torConnFinished() {
+        DispatchQueue.main.async { [unowned vc = self] in
+            vc.mainMenu.alpha = 1
+        }
         bootStrapping = false
         torConnected = true
         reloadSections([torCellIndex])

--- a/XCode/GordianWallet/View Controllers/Home Screen/MainMenuViewController.swift
+++ b/XCode/GordianWallet/View Controllers/Home Screen/MainMenuViewController.swift
@@ -388,6 +388,11 @@ class MainMenuViewController: UIViewController, UITableViewDelegate, UITableView
         if ud?.object(forKey: "feeTarget") ==  nil {
             ud?.set(432, forKey: "feeTarget")
         }
+        getActiveWalletNow { [unowned vc = self] (wallet, error) in
+            if wallet != nil {
+                vc.wallet = wallet!
+            }
+        }
         #if DEBUG
         didAppear()
         #else

--- a/XCode/GordianWallet/View Controllers/Home Screen/MainMenuViewController.swift
+++ b/XCode/GordianWallet/View Controllers/Home Screen/MainMenuViewController.swift
@@ -999,7 +999,7 @@ class MainMenuViewController: UIViewController, UITableViewDelegate, UITableView
     private func torsCell(_ indexPath: IndexPath) -> UITableViewCell {
         self.torCellIndex = indexPath.section
         if !torConnected {
-            return descriptionCell(description: "⚠︎ Tor not connected")
+            return descriptionCell(description: "⚠︎ Connection to node failed")
         } else {
             
             if node != nil {
@@ -1303,6 +1303,7 @@ class MainMenuViewController: UIViewController, UITableViewDelegate, UITableView
         existingWalletName = wallet.name!
         nodeLogic?.loadWalletData(wallet: wallet) { [unowned vc = self] (success, dictToReturn, errorDesc) in
             if success && dictToReturn != nil {
+                vc.torConnected = true
                 /// we update the wallets database in NodeLogic, so we need to refresh the wallet struct here
                 getActiveWalletNow { (w, error) in
                     if w != nil {
@@ -1331,6 +1332,7 @@ class MainMenuViewController: UIViewController, UITableViewDelegate, UITableView
         isRefreshingWalletData = true
         nodeLogic?.loadWalletData(wallet: wallet) { [unowned vc = self] (success, dictToReturn, errorDesc) in
             if success && dictToReturn != nil {
+                vc.torConnected = true
                 /// we update the wallets database in NodeLogic, so we need to refresh the wallet struct here
                 getActiveWalletNow { (w, error) in
                     if w != nil {
@@ -1357,6 +1359,7 @@ class MainMenuViewController: UIViewController, UITableViewDelegate, UITableView
             updateLabel(text: "     Getting network info from your node...")
             nodeLogic?.loadTorData { [unowned vc = self] (success, dictToReturn, errorDesc) in
                 if success && dictToReturn != nil {
+                    vc.torConnected = true
                     vc.torInfo = HomeStruct(dictionary: dictToReturn!)
                     vc.torSectionLoaded = true
                     vc.isRefreshingTorData = false
@@ -1388,6 +1391,7 @@ class MainMenuViewController: UIViewController, UITableViewDelegate, UITableView
         if node != nil {
             nodeLogic?.loadTorData { [unowned vc = self] (success, dictToReturn, errorDesc) in
                 if success && dictToReturn != nil {
+                    vc.torConnected = true
                     vc.torInfo = HomeStruct(dictionary: dictToReturn!)
                     vc.torSectionLoaded = true
                     vc.isRefreshingTorData = false
@@ -1411,6 +1415,7 @@ class MainMenuViewController: UIViewController, UITableViewDelegate, UITableView
         updateLabel(text: "     Getting Full Node data...")
         nodeLogic?.loadNodeData(node: node) { [unowned vc = self] (success, dictToReturn, errorDesc) in
             if success && dictToReturn != nil {
+                vc.torConnected = true
                 vc.nodeInfo = HomeStruct(dictionary: dictToReturn!)
                 vc.nodeSectionLoaded = true
                 vc.isRefreshingNodeData = false
@@ -1438,6 +1443,7 @@ class MainMenuViewController: UIViewController, UITableViewDelegate, UITableView
         isRefreshingNodeData = true
         nodeLogic?.loadNodeData(node: node) { [unowned vc = self] (success, dictToReturn, errorDesc) in
             if success && dictToReturn != nil {
+                vc.torConnected = true
                 vc.nodeInfo = HomeStruct(dictionary: dictToReturn!)
                 vc.nodeSectionLoaded = true
                 vc.isRefreshingNodeData = false
@@ -1456,6 +1462,7 @@ class MainMenuViewController: UIViewController, UITableViewDelegate, UITableView
         nodeLogic?.loadTransactionData(wallet: wallet) { [unowned vc = self] (success, transactions, errorDesc) in
             if success && transactions != nil {
                 DispatchQueue.main.async {
+                    vc.torConnected = true
                     vc.transactionArray = transactions!.reversed()
                     vc.transactionsSectionLoaded = true
                     vc.mainMenu.reloadData()
@@ -1474,6 +1481,7 @@ class MainMenuViewController: UIViewController, UITableViewDelegate, UITableView
     private func refreshTransactions(_ sender: UIButton) {
         nodeLogic?.loadTransactionData(wallet: wallet) { [unowned vc = self] (success, transactions, errorDesc) in
             if success && transactions != nil {
+                vc.torConnected = true
                 vc.transactionArray.removeAll()
                 vc.transactionArray = transactions!.reversed()
                 vc.transactionsSectionLoaded = true

--- a/XCode/GordianWallet/View Controllers/Home Screen/Transaction Viewer/TransactionViewController.swift
+++ b/XCode/GordianWallet/View Controllers/Home Screen/Transaction Viewer/TransactionViewController.swift
@@ -130,20 +130,24 @@ class TransactionViewController: UIViewController, UITableViewDelegate, UITableV
     }
     
     private func inputsCell(indexPath: IndexPath) -> UITableViewCell {
-        let inputCell = transactionTable.dequeueReusableCell(withIdentifier: "inputsOutputsCell", for: indexPath)
-        let inputIndexLabel = inputCell.viewWithTag(1) as! UILabel
-        let inputAmountLabel = inputCell.viewWithTag(2) as! UILabel
-        let inputAddressLabel = inputCell.viewWithTag(3) as! UILabel
-        let input = inputTableArray[indexPath.row]
-        inputIndexLabel.text = "Input #\(input["index"] as! Int)"
-        inputAmountLabel.text = "\((input["amount"] as! String)) btc"
-        inputAddressLabel.text = (input["address"] as! String)
-        inputAddressLabel.adjustsFontSizeToFitWidth = true
-        inputCell.selectionStyle = .none
-        inputIndexLabel.textColor = .lightGray
-        inputAmountLabel.textColor = .lightGray
-        inputAddressLabel.textColor = .lightGray
-        return inputCell
+        if inputTableArray.count > 0 {
+            let inputCell = transactionTable.dequeueReusableCell(withIdentifier: "inputsOutputsCell", for: indexPath)
+            let inputIndexLabel = inputCell.viewWithTag(1) as! UILabel
+            let inputAmountLabel = inputCell.viewWithTag(2) as! UILabel
+            let inputAddressLabel = inputCell.viewWithTag(3) as! UILabel
+            let input = inputTableArray[indexPath.row]
+            inputIndexLabel.text = "Input #\(input["index"] as! Int)"
+            inputAmountLabel.text = "\((input["amount"] as! String)) btc"
+            inputAddressLabel.text = (input["address"] as! String)
+            inputAddressLabel.adjustsFontSizeToFitWidth = true
+            inputCell.selectionStyle = .none
+            inputIndexLabel.textColor = .lightGray
+            inputAmountLabel.textColor = .lightGray
+            inputAddressLabel.textColor = .lightGray
+            return inputCell
+        } else {
+            return UITableViewCell()
+        }
     }
     
     private func outputsCell(indexPath: IndexPath) -> UITableViewCell {

--- a/XCode/GordianWallet/View Controllers/Wallets/Wallet Recovery/WordRecoveryViewController.swift
+++ b/XCode/GordianWallet/View Controllers/Wallets/Wallet Recovery/WordRecoveryViewController.swift
@@ -1019,7 +1019,7 @@ class WordRecoveryViewController: UIViewController, UITextFieldDelegate, UINavig
                 vc.recoveryDict["birthdate"] = keyBirthday()
                 vc.recoveryDict["nodeIsSigner"] = false
                 
-                for desc in vc.processedPrimaryDescriptors {
+                for (i, desc) in vc.processedPrimaryDescriptors.enumerated() {
                     
                     DispatchQueue.main.async { [unowned vc = self] in
                         if vc.derivationField.text != "" {
@@ -1031,14 +1031,15 @@ class WordRecoveryViewController: UIViewController, UITextFieldDelegate, UINavig
                             } else if desc.contains("/1/*") {
                                 vc.recoveryDict["changeDescriptor"] = desc
                             }
-                            
-                            vc.setCustomXprvs { (success) in
-                                if success {
-                                    vc.cv.removeConnectingView()
-                                    vc.confirm()
-                                } else {
-                                    vc.cv.removeConnectingView()
-                                    showAlert(vc: vc, title: "Error", message: "There was an error encrypting your xprvs.")
+                            if i + 1 == vc.processedPrimaryDescriptors.count {
+                                vc.setCustomXprvs { (success) in
+                                    if success {
+                                        vc.cv.removeConnectingView()
+                                        vc.confirm()
+                                    } else {
+                                        vc.cv.removeConnectingView()
+                                        showAlert(vc: vc, title: "Error", message: "There was an error encrypting your xprvs.")
+                                    }
                                 }
                             }
                             
@@ -1054,13 +1055,15 @@ class WordRecoveryViewController: UIViewController, UITextFieldDelegate, UINavig
                                 }
                             }
                             
-                            vc.setXprvs { (success) in
-                                if success {
-                                    vc.cv.removeConnectingView()
-                                    vc.confirm()
-                                } else {
-                                    vc.cv.removeConnectingView()
-                                    showAlert(vc: vc, title: "Error", message: "There was an error encrypting your xprvs.")
+                            if i + 1 == vc.processedPrimaryDescriptors.count {
+                                vc.setXprvs { (success) in
+                                    if success {
+                                        vc.cv.removeConnectingView()
+                                        vc.confirm()
+                                    } else {
+                                        vc.cv.removeConnectingView()
+                                        showAlert(vc: vc, title: "Error", message: "There was an error encrypting your xprvs.")
+                                    }
                                 }
                             }
                         }

--- a/XCode/GordianWallet/View Controllers/Wallets/Wallet Recovery/WordRecoveryViewController.swift
+++ b/XCode/GordianWallet/View Controllers/Wallets/Wallet Recovery/WordRecoveryViewController.swift
@@ -1089,7 +1089,7 @@ class WordRecoveryViewController: UIViewController, UITextFieldDelegate, UINavig
                 vc.changeDescriptors = processedChangeDescriptors
                 vc.primaryDescriptors = processedPrimaryDescriptors
                 vc.updateDerivationBlock = { [unowned thisVc = self] dict in
-                    thisVc.cv.addConnectingView(vc: self, description: "building your wallets descriptors, this can take a minute..")
+                    thisVc.cv.addConnectingView(vc: self, description: "building your account descriptors, this can take a minute..")
                     if let wrds = dict["words"], let der = dict["derivation"] {
                         Encryption.getNode { (node, error) in
                             if node != nil {

--- a/XCode/GordianWallet/View Controllers/Wallets/Wallet Recovery/WordRecoveryViewController.swift
+++ b/XCode/GordianWallet/View Controllers/Wallets/Wallet Recovery/WordRecoveryViewController.swift
@@ -210,8 +210,6 @@ class WordRecoveryViewController: UIViewController, UITextFieldDelegate, UINavig
     }
     
     private func processTextfieldInput() {
-        print("processTextfieldInput")
-        
         if textField.text != "" {
             
             //check if user pasted more then one word
@@ -1005,6 +1003,27 @@ class WordRecoveryViewController: UIViewController, UITextFieldDelegate, UINavig
                 vc.derivation = self.derivation
                 vc.changeDescriptors = processedChangeDescriptors
                 vc.primaryDescriptors = processedPrimaryDescriptors
+                vc.updateDerivationBlock = { [unowned thisVc = self] dict in
+                    thisVc.cv.addConnectingView(vc: self, description: "building your wallets descriptors, this can take a minute..")
+                    if let wrds = dict["words"], let der = dict["derivation"] {
+                        Encryption.getNode { (node, error) in
+                            if node != nil {
+                                thisVc.index = 0
+                                thisVc.recoveryDict = [:]
+                                thisVc.recoveryDict["nodeId"] = node!.id
+                                thisVc.walletNameHash = ""
+                                thisVc.processedChangeDescriptors.removeAll()
+                                thisVc.processedPrimaryDescriptors.removeAll()
+                                thisVc.words = wrds
+                                thisVc.derivation = der.replacingOccurrences(of: "/0/0", with: "")
+                                thisVc.derivation = thisVc.derivation!.condenseWhitespace()
+                                thisVc.recoveryDict["derivation"] = thisVc.derivation
+                                let (primDescriptors, changeDescriptors) = thisVc.descriptors()
+                                thisVc.buildPrimDescriptors(primDescriptors, changeDescriptors)
+                            }
+                        }
+                    }
+                }
             }
             
         default:

--- a/XCode/GordianWallet/View Controllers/Wallets/Wallet Tools/ExportKeysViewController.swift
+++ b/XCode/GordianWallet/View Controllers/Wallets/Wallet Tools/ExportKeysViewController.swift
@@ -614,21 +614,27 @@ class ExportKeysViewController: UIViewController, UITableViewDelegate, UITableVi
     }
 
     private func fetchKeysFromXpub(xpub: HDKey) {
-
         let derivation = wallet.derivation
         var addressType:AddressType!
+        
         if derivation.contains("84") {
-
             addressType = .payToWitnessPubKeyHash
-
         } else if derivation.contains("44") {
-
             addressType = .payToPubKeyHash
-
         } else if derivation.contains("49") {
-
             addressType = .payToScriptHashPayToWitnessPubKeyHash
-
+        } else {
+            // To cover custom derivs
+            let descriptor = wallet.descriptor
+            let descriptorParser = DescriptorParser()
+            let descriptorStruct = descriptorParser.descriptor(descriptor)
+            if descriptorStruct.isP2PKH {
+                addressType = .payToPubKeyHash
+            } else if descriptorStruct.isP2SHP2WPKH {
+                addressType = .payToScriptHashPayToWitnessPubKeyHash
+            } else if descriptorStruct.isP2WPKH {
+                addressType = .payToScriptHashPayToWitnessPubKeyHash
+            }
         }
 
         for i in 0 ... 999 {

--- a/XCode/GordianWallet/View Controllers/Wallets/Wallets Table/WalletsViewController.swift
+++ b/XCode/GordianWallet/View Controllers/Wallets/Wallets Table/WalletsViewController.swift
@@ -259,9 +259,7 @@ class WalletsViewController: UIViewController, UITableViewDelegate, UITableViewD
             let wstruct = WalletStruct(dictionary: wallet)
             SeedParser.getSigners(wallet: wstruct) { [unowned vc = self] (knownSigners, uknownSigners) in
                 vc.sortedWallets[i]["knownSigners"] = knownSigners
-                print("knownSigners: \(knownSigners)")
                 vc.sortedWallets[i]["unknownSigners"] = uknownSigners
-                print("uknownSigners: \(uknownSigners)")
                 if i + 1 == vc.sortedWallets.count {
                     vc.sortedWallets = vc.sortedWallets.sorted{ ($0["lastUsed"] as? Date ?? Date()) > ($1["lastUsed"] as? Date ?? Date()) }
                     completion(true)
@@ -405,12 +403,10 @@ class WalletsViewController: UIViewController, UITableViewDelegate, UITableViewD
         
         let derivation = walletStruct.derivation
         
-        if derivation.contains("1") {
-            
+        if walletStruct.descriptor.contains("tpub") {
             balanceLabel.textColor = .systemOrange
             
         } else {
-            
             balanceLabel.textColor = .systemGreen
             
         }

--- a/XCode/GordianWallet/View Controllers/Wallets/Wallets Table/WalletsViewController.swift
+++ b/XCode/GordianWallet/View Controllers/Wallets/Wallets Table/WalletsViewController.swift
@@ -985,44 +985,44 @@ class WalletsViewController: UIViewController, UITableViewDelegate, UITableViewD
 //-------------------------------------------------------------------------------
 // MARK: - To enable mainnet accounts just uncomment the following lines of code:
 //
-//            DispatchQueue.main.async { [unowned vc = self] in
-//
-//                vc.performSegue(withIdentifier: "addWallet", sender: vc)
-//
-//            }
+            DispatchQueue.main.async { [unowned vc = self] in
+
+                vc.performSegue(withIdentifier: "addWallet", sender: vc)
+
+            }
 //-------------------------------------------------------------------------------
 // MARK: - And comment out the following lines of code:
 
-            Encryption.getNode { [unowned vc = self] (node, error) in
-
-                if !error && node != nil {
-
-                    if node!.network == "mainnet" {
-
-                        DispatchQueue.main.async {
-                            let alert = UIAlertController(title: "We appreciate your patience", message: "We are still adding new features, so mainnet wallets are disabled. Please help us test.", preferredStyle: .actionSheet)
-                            alert.addAction(UIAlertAction(title: "Understood", style: .default, handler: { action in }))
-                            alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: { action in }))
-                            vc.present(alert, animated: true, completion: nil)
-                        }
-
-                    } else {
-
-                        DispatchQueue.main.async {
-
-                            vc.performSegue(withIdentifier: "addWallet", sender: vc)
-
-                        }
-
-                    }
-
-                } else {
-
-                    displayAlert(viewController: vc, isError: true, message: "No active nodes")
-
-                }
-
-            }
+//            Encryption.getNode { [unowned vc = self] (node, error) in
+//
+//                if !error && node != nil {
+//
+//                    if node!.network == "mainnet" {
+//
+//                        DispatchQueue.main.async {
+//                            let alert = UIAlertController(title: "We appreciate your patience", message: "We are still adding new features, so mainnet wallets are disabled. Please help us test.", preferredStyle: .actionSheet)
+//                            alert.addAction(UIAlertAction(title: "Understood", style: .default, handler: { action in }))
+//                            alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: { action in }))
+//                            vc.present(alert, animated: true, completion: nil)
+//                        }
+//
+//                    } else {
+//
+//                        DispatchQueue.main.async {
+//
+//                            vc.performSegue(withIdentifier: "addWallet", sender: vc)
+//
+//                        }
+//
+//                    }
+//
+//                } else {
+//
+//                    displayAlert(viewController: vc, isError: true, message: "No active nodes")
+//
+//                }
+//
+//            }
 //-------------------------------------------------------------------------------
             
         } else {

--- a/XCode/GordianWallet/View Controllers/Wallets/Wallets Table/WalletsViewController.swift
+++ b/XCode/GordianWallet/View Controllers/Wallets/Wallets Table/WalletsViewController.swift
@@ -989,44 +989,44 @@ class WalletsViewController: UIViewController, UITableViewDelegate, UITableViewD
 //-------------------------------------------------------------------------------
 // MARK: - To enable mainnet accounts just uncomment the following lines of code:
 //
-//            DispatchQueue.main.async { [unowned vc = self] in
-//
-//                vc.performSegue(withIdentifier: "addWallet", sender: vc)
-//
-//            }
+            DispatchQueue.main.async { [unowned vc = self] in
+
+                vc.performSegue(withIdentifier: "addWallet", sender: vc)
+
+            }
 //-------------------------------------------------------------------------------
 // MARK: - And comment out the following lines of code:
 
-            Encryption.getNode { [unowned vc = self] (node, error) in
-
-                if !error && node != nil {
-
-                    if node!.network == "mainnet" {
-
-                        DispatchQueue.main.async {
-                            let alert = UIAlertController(title: "We appreciate your patience", message: "We are still adding new features, so mainnet wallets are disabled. Please help us test.", preferredStyle: .actionSheet)
-                            alert.addAction(UIAlertAction(title: "Understood", style: .default, handler: { action in }))
-                            alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: { action in }))
-                            vc.present(alert, animated: true, completion: nil)
-                        }
-
-                    } else {
-
-                        DispatchQueue.main.async {
-
-                            vc.performSegue(withIdentifier: "addWallet", sender: vc)
-
-                        }
-
-                    }
-
-                } else {
-
-                    displayAlert(viewController: vc, isError: true, message: "No active nodes")
-
-                }
-
-            }
+//            Encryption.getNode { [unowned vc = self] (node, error) in
+//
+//                if !error && node != nil {
+//
+//                    if node!.network == "mainnet" {
+//
+//                        DispatchQueue.main.async {
+//                            let alert = UIAlertController(title: "We appreciate your patience", message: "We are still adding new features, so mainnet wallets are disabled. Please help us test.", preferredStyle: .actionSheet)
+//                            alert.addAction(UIAlertAction(title: "Understood", style: .default, handler: { action in }))
+//                            alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: { action in }))
+//                            vc.present(alert, animated: true, completion: nil)
+//                        }
+//
+//                    } else {
+//
+//                        DispatchQueue.main.async {
+//
+//                            vc.performSegue(withIdentifier: "addWallet", sender: vc)
+//
+//                        }
+//
+//                    }
+//
+//                } else {
+//
+//                    displayAlert(viewController: vc, isError: true, message: "No active nodes")
+//
+//                }
+//
+//            }
 //-------------------------------------------------------------------------------
             
         } else {

--- a/XCode/GordianWallet/View Controllers/Wallets/Wallets Table/WalletsViewController.swift
+++ b/XCode/GordianWallet/View Controllers/Wallets/Wallets Table/WalletsViewController.swift
@@ -985,44 +985,44 @@ class WalletsViewController: UIViewController, UITableViewDelegate, UITableViewD
 //-------------------------------------------------------------------------------
 // MARK: - To enable mainnet accounts just uncomment the following lines of code:
 //
-            DispatchQueue.main.async { [unowned vc = self] in
-
-                vc.performSegue(withIdentifier: "addWallet", sender: vc)
-
-            }
+//            DispatchQueue.main.async { [unowned vc = self] in
+//
+//                vc.performSegue(withIdentifier: "addWallet", sender: vc)
+//
+//            }
 //-------------------------------------------------------------------------------
 // MARK: - And comment out the following lines of code:
 
-//            Encryption.getNode { [unowned vc = self] (node, error) in
-//
-//                if !error && node != nil {
-//
-//                    if node!.network == "mainnet" {
-//
-//                        DispatchQueue.main.async {
-//                            let alert = UIAlertController(title: "We appreciate your patience", message: "We are still adding new features, so mainnet wallets are disabled. Please help us test.", preferredStyle: .actionSheet)
-//                            alert.addAction(UIAlertAction(title: "Understood", style: .default, handler: { action in }))
-//                            alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: { action in }))
-//                            vc.present(alert, animated: true, completion: nil)
-//                        }
-//
-//                    } else {
-//
-//                        DispatchQueue.main.async {
-//
-//                            vc.performSegue(withIdentifier: "addWallet", sender: vc)
-//
-//                        }
-//
-//                    }
-//
-//                } else {
-//
-//                    displayAlert(viewController: vc, isError: true, message: "No active nodes")
-//
-//                }
-//
-//            }
+            Encryption.getNode { [unowned vc = self] (node, error) in
+
+                if !error && node != nil {
+
+                    if node!.network == "mainnet" {
+
+                        DispatchQueue.main.async {
+                            let alert = UIAlertController(title: "We appreciate your patience", message: "We are still adding new features, so mainnet wallets are disabled. Please help us test.", preferredStyle: .actionSheet)
+                            alert.addAction(UIAlertAction(title: "Understood", style: .default, handler: { action in }))
+                            alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: { action in }))
+                            vc.present(alert, animated: true, completion: nil)
+                        }
+
+                    } else {
+
+                        DispatchQueue.main.async {
+
+                            vc.performSegue(withIdentifier: "addWallet", sender: vc)
+
+                        }
+
+                    }
+
+                } else {
+
+                    displayAlert(viewController: vc, isError: true, message: "No active nodes")
+
+                }
+
+            }
 //-------------------------------------------------------------------------------
             
         } else {


### PR DESCRIPTION
Users may now add a custom derivation path when recovering single sig with words.
For example if a user supplies `m/0'/0'` as a derivation then internally we generate receive keys with `m/0'/0'/0/0` and change keys with `m/0'/0'/1/0`.

If a user is recovering an account with words only we now auto scan each derivation `BIP44/84/49` at account 0 address index 0 `m/84'/0'/0'/0/0` as `BIP84` example to see if the addresses have history on other popular derivations. If they do we will ask the user if they would like to recover the account with history and automate the process for them.

When a user is recovering a single sig account with words only we automatically recover sub accounts 0-9 as a `BIP84` example:
```
# Account 0
m/84'/0'/0'/0/*
m/84'/0'/0'/1/*

# Account 1
m/84'/0'/1'/0/*
m/84'/0'/1'/1/*

# Account 2
m/84'/0'/2'/0/*
m/84'/0'/2'/1/*

# etc... up to Account 9
``` 

Account 0 is always added to the keypool whereas the other accounts are for "watching" and not added to the keypool, since we save the account xprv for each they are all spendable, hence it is a recovery account.

If the account already exists on the node we do not do this at is seems pointless, considering they have already got an active account they are obviously trying to recover that specific account, it simply and quickly adds the account locally linking to its counterpart on the node as normal.

We also do not check any sub accounts if they are recovering with an account map as again they clearly already have a specific account they want to recover. 

Keep in mind it takes significantly longer to recover 0-9 sub accounts instead of one specific account, 40 rpc commands vs 4.