### PR TITLE
Enhancements

### DIFF
--- a/XCode/GordianWallet.xcodeproj/project.pbxproj
+++ b/XCode/GordianWallet.xcodeproj/project.pbxproj
@@ -1400,7 +1400,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 0.1.95;
+				CURRENT_PROJECT_VERSION = 0.1.98;
 				DEPLOYMENT_POSTPROCESSING = NO;
 				DEVELOPMENT_TEAM = YZHG975W3A;
 				ENABLE_BITCODE = NO;
@@ -1410,7 +1410,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.95;
+				MARKETING_VERSION = 0.1.98;
 				PRODUCT_BUNDLE_IDENTIFIER = com.blockchaincommons.standupios;
 				PRODUCT_NAME = "Gordian Wallet";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1430,7 +1430,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = GordianWallet/GordianWallet.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 0.1.95;
+				CURRENT_PROJECT_VERSION = 0.1.98;
 				DEPLOYMENT_POSTPROCESSING = NO;
 				DEVELOPMENT_TEAM = YZHG975W3A;
 				ENABLE_BITCODE = NO;
@@ -1440,7 +1440,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.95;
+				MARKETING_VERSION = 0.1.98;
 				PRODUCT_BUNDLE_IDENTIFIER = com.blockchaincommons.standupios;
 				PRODUCT_NAME = "Gordian Wallet";
 				SUPPORTS_MACCATALYST = YES;

--- a/XCode/GordianWallet.xcodeproj/xcshareddata/xcschemes/GordianWallet.xcscheme
+++ b/XCode/GordianWallet.xcodeproj/xcshareddata/xcschemes/GordianWallet.xcscheme
@@ -51,7 +51,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/XCode/GordianWallet/Helpers/DescriptorParser.swift
+++ b/XCode/GordianWallet/Helpers/DescriptorParser.swift
@@ -257,9 +257,9 @@ class DescriptorParser {
                 let arr4 = extendedKeyWithPath.split(separator: "/")
                 let extendedKey = arr4[0]
                 if extendedKey.contains("tpub") || extendedKey.contains("xpub") {
-                    dict["accountXpub"] = "\(extendedKey)"
+                    dict["accountXpub"] = "\(extendedKey.replacingOccurrences(of: ")", with: ""))"
                 } else if extendedKey.contains("tprv") || extendedKey.contains("xprv") {
-                    dict["accountXprv"] = "\(extendedKey)"
+                    dict["accountXprv"] = "\(extendedKey.replacingOccurrences(of: ")", with: ""))"
                 }
                 
                 let arr3 = derivation.split(separator: "/")

--- a/XCode/GordianWallet/Helpers/LifeHashImage.swift
+++ b/XCode/GordianWallet/Helpers/LifeHashImage.swift
@@ -12,7 +12,16 @@ import UIKit
 enum LifeHash {
     
     static func image(_ input: String) -> UIImage {
-        return LifeHashGenerator.generateSync(input)
+        let arr = input.split(separator: "#")
+        var bare = ""
+        
+        if arr.count > 0 {
+            bare = "\(arr[0])".replacingOccurrences(of: "'", with: "h")
+        } else {
+            bare = input.replacingOccurrences(of: "'", with: "h")
+        }
+        
+        return LifeHashGenerator.generateSync(bare)
     }
     
 }

--- a/XCode/GordianWallet/Node Logic/NodeLogic.swift
+++ b/XCode/GordianWallet/Node Logic/NodeLogic.swift
@@ -68,7 +68,7 @@ class NodeLogic {
                 vc.parseUtxos(wallet: wallet, utxos: utxos, completion: completion)
                 
             } else {
-                completion((true, nil, nil))
+                completion((true, nil, errorDesc))
                 
             }
         }
@@ -80,7 +80,7 @@ class NodeLogic {
                 vc.parseUtxos(wallet: wallet, utxos: utxos, completion: completion)
                 
             } else {
-                completion((true, nil, nil))
+                completion((true, nil, errorDesc))
                 
             }
         }

--- a/XCode/GordianWallet/View Controllers/Home Screen/MainMenuViewController.swift
+++ b/XCode/GordianWallet/View Controllers/Home Screen/MainMenuViewController.swift
@@ -111,29 +111,9 @@ class MainMenuViewController: UIViewController, UITableViewDelegate, UITableView
         }
         
         firstTimeHere()
-        checkIfoutdated()
         
         if (UIDevice.current.userInterfaceIdiom == .pad) {
           alertStyle = UIAlertController.Style.alert
-        }
-    }
-    
-    private func checkIfoutdated() {
-        CoreDataService.retrieveEntity(entityName: .wallets) { [unowned vc = self] (wallets, errorDescription) in
-            if wallets != nil {
-                var isOutdated = true
-                for (i, wallet) in wallets!.enumerated() {
-                    let walletStruct = WalletStruct(dictionary: wallet)
-                    if walletStruct.xprvs != nil {
-                        isOutdated = false
-                    }
-                    if i + 1 == wallets!.count {
-                        if isOutdated {
-                            showAlert(vc: vc, title: "Important!", message: "We recently made some fundamental changes to how the app stores seeds and derives signing keys, this means the app will no longer be able to sign for outdated accounts. Make sure you back up all your account info, then utilize both kill switches, force quit and reopen the app then recover your existing accounts. If you have only just downloaded the app and have not yet created any accounts then this message can be ignored.")
-                        }
-                    }
-                }
-            }
         }
     }
     
@@ -437,6 +417,7 @@ class MainMenuViewController: UIViewController, UITableViewDelegate, UITableView
     }
     
     private func didAppear() {
+        print("didAppear")
         
         DispatchQueue.main.async {
             Encryption.getNode { [unowned vc = self] (node, error) in
@@ -1622,6 +1603,7 @@ class MainMenuViewController: UIViewController, UITableViewDelegate, UITableView
             vc.mainMenu.reloadData()
             vc.existingWalletName = ""
         }
+        
         getActiveWalletNow() { [unowned vc = self] (w, error) in
             if !error && w != nil {
                 vc.wallet = w!

--- a/XCode/GordianWallet/View Controllers/Wallets/Seed/SeedViewController.swift
+++ b/XCode/GordianWallet/View Controllers/Wallets/Seed/SeedViewController.swift
@@ -991,6 +991,8 @@ class SeedViewController: UIViewController, UITableViewDelegate, UITableViewData
 
             }
                 
+        } else {
+            print("no user identifier")
         }
 
     }

--- a/XCode/GordianWallet/View Controllers/Wallets/Wallet Creation/WalletCreatedSuccessViewController.swift
+++ b/XCode/GordianWallet/View Controllers/Wallets/Wallet Creation/WalletCreatedSuccessViewController.swift
@@ -103,12 +103,12 @@ class WalletCreatedSuccessViewController: UIViewController, UITextFieldDelegate,
     }
     
     @objc func handleTap() {
-        
+        #if targetEnvironment(macCatalyst)
+        #else
         DispatchQueue.main.async { [unowned vc = self] in
-            
             vc.textField.resignFirstResponder()
-            
         }
+        #endif
         
     }
     

--- a/XCode/GordianWallet/View Controllers/Wallets/Wallet Recovery/ConfirmRecoveryViewController.swift
+++ b/XCode/GordianWallet/View Controllers/Wallets/Wallet Recovery/ConfirmRecoveryViewController.swift
@@ -241,10 +241,9 @@ class ConfirmRecoveryViewController: UIViewController, UITableViewDelegate, UITa
     }
     
     func rescanFrom(param: String, wallet: WalletStruct) {
-        Reducer.makeCommand(walletName: wallet.name ?? walletNameHash, command: .rescanblockchain, param: param) { [unowned vc = self] (object, errorDescription) in
-            vc.connectingView.removeConnectingView()
-            vc.walletSuccessfullyCreated(wallet: wallet)
-        }
+        Reducer.makeCommand(walletName: wallet.name ?? walletNameHash, command: .rescanblockchain, param: param) { (_, _) in }
+        connectingView.removeConnectingView()
+        walletSuccessfullyCreated(wallet: wallet)
     }
     
     func rescan(wallet: WalletStruct) {
@@ -265,10 +264,9 @@ class ConfirmRecoveryViewController: UIViewController, UITableViewDelegate, UITa
                             vc.showError(message: errorDescription ?? "unknown error")
                         }
                     } else {
-                        Reducer.makeCommand(walletName: wallet.name ?? vc.walletNameHash, command: .rescanblockchain, param: "\(wallet.blockheight)") { [unowned vc = self] (object, errorDescription) in
-                            vc.connectingView.removeConnectingView()
-                            vc.walletSuccessfullyCreated(wallet: wallet)
-                        }
+                        Reducer.makeCommand(walletName: wallet.name ?? vc.walletNameHash, command: .rescanblockchain, param: "\(wallet.blockheight)") { (_, _) in }
+                        vc.connectingView.removeConnectingView()
+                        vc.walletSuccessfullyCreated(wallet: wallet)
                     }
                 } else {
                     vc.showError(message: errorDescription ?? "unknown error")

--- a/XCode/GordianWallet/View Controllers/Wallets/Wallet Recovery/WordRecoveryViewController.swift
+++ b/XCode/GordianWallet/View Controllers/Wallets/Wallet Recovery/WordRecoveryViewController.swift
@@ -455,13 +455,10 @@ class WordRecoveryViewController: UIViewController, UITextFieldDelegate, UINavig
     }
     
     private func parse(text: String) {
-        print("parse")
         if text.lowercased().hasPrefix("ur:crypto-seed/") {
             if let data = URHelper.urToEntropy(urString: text).data {
-                print("data: \(data)")
                 let entropy = BIP39Entropy(data)
                 if let mnemonic = BIP39Mnemonic(entropy) {
-                    print("mnemonic: \(mnemonic)")
                     let words = mnemonic.words.joined(separator: " ")
                     DispatchQueue.main.async { [unowned vc = self] in
                         vc.textField.text = words


### PR DESCRIPTION
This PR adds some important updates:

- we now automatically add range to any non ranged descriptor, for example Sparrow Wallet and LetheKit do not provide a ranged descriptor when exporting wallets

- we now lexicographically sort the xpubs when we import an Account Map, that way we can always know for certain similar accounts will result in the same wallet.dat filename which results in greatly improved UX as we will always automatically reuse the correct wallet.dat file on the node, and it guarantees the lifehash will be identical even if the user creates their descriptor with xpub's in a different order then another wallet software may have. See this issue for more explanation: [https://github.com/cryptoadvance/specter-desktop/issues/436](https://github.com/cryptoadvance/specter-desktop/issues/436)

- we no longer wait for a response from bitcoind when intitiating a rescan as it bogs everything down and can take a very long time. Results in much improved UX around wallet recovery and importing.